### PR TITLE
 test push-image gha

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,8 +1,12 @@
 name: image
 
 on:
-  pull_request:
+  push:
     branches: [ v1alpha1 ]
+
+env:  
+  OPERATOR_IMAGE: "quay.io/sustainable_computing_io/kepler-operator"
+
 
 jobs:
   image_build:
@@ -21,35 +25,35 @@ jobs:
         password: ${{ secrets.BOT_TOKEN }}
 
 
-# push-image:
-#     name: Push operator container image to quay.io/sustainable_computing_io/kepler-operator
-#     needs: [build-operator,e2e]
-#     runs-on: ubuntu-latest
-#     steps: 
+  # push-image:
+  #     name: Push operator container image to quay.io/sustainable_computing_io/kepler-operator
+  #     needs: [build-operator,e2e]
+  #     runs-on: ubuntu-latest
+  #     steps: 
 
-#       - name: Login to quay.io/sustainable_computing_io/
-#         uses: docker/login-action@v1
-#         if: ${{ (github.repository_owner == 'sustainable-computing-io') && (github.ref == 'refs/heads/v1alpha1') }}
+  #       - name: Login to quay.io/sustainable_computing_io/
+  #         uses: docker/login-action@v1
+  #         if: ${{ (github.repository_owner == 'sustainable-computing-io') && (github.ref == 'refs/heads/v1alpha1') }}
 
-#         with:
-#           registry: quay.io/sustainable_computing_io
-#           username: ${{ secrets.BOT_NAME }}
-#           password: ${{ secrets.BOT_TOKEN }}
+  #         with:
+  #           registry: quay.io/sustainable_computing_io
+  #           username: ${{ secrets.BOT_NAME }}
+  #           password: ${{ secrets.BOT_TOKEN }}
 
-#       - name: Download image bundle
-#         uses: actions/download-artifact@v3
-#         with:
-#           name: kepler-operator
+  #       - name: Download image bundle
+  #         uses: actions/download-artifact@v3
+  #         with:
+  #           name: kepler-operator
 
-#       - name: Test artifact download
-#         run : |
-#           ls -R
-#           pwd
-#       - name: Push to quay
-#         if: ${{ (github.repository_owner == 'sustainable-computing-io') && (github.ref == 'refs/heads/v1alpha1') }}
-#         run: |
-#           docker load -i image.tar
-#           docker inspect ${OPERATOR_IMAGE}
-#           docker tag ${OPERATOR_IMAGE} ${OPERATOR_IMAGE}:latest
-#           docker push ${OPERATOR_IMAGE}:latest 
+  #       - name: Test artifact download
+  #         run : |
+  #           ls -R
+  #           pwd
+  #       - name: Push to quay
+  #         if: ${{ (github.repository_owner == 'sustainable-computing-io') && (github.ref == 'refs/heads/v1alpha1') }}
+  #         run: |
+  #           docker load -i image.tar
+  #           docker inspect ${OPERATOR_IMAGE}
+  #           docker tag ${OPERATOR_IMAGE} ${OPERATOR_IMAGE}:latest
+  #           docker push ${OPERATOR_IMAGE}:latest 
     

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -116,7 +116,6 @@ jobs:
       
       - name: Login to quay.io/sustainable_computing_io/
         uses: docker/login-action@v1
-        if: ${{ (github.repository_owner == 'sustainable-computing-io') && (github.ref == 'refs/heads/v1alpha1') }}
 
         with:
           registry: quay.io/sustainable_computing_io
@@ -134,7 +133,6 @@ jobs:
           pwd
 
       - name: Push to quay
-        if: ${{ (github.repository_owner == 'sustainable-computing-io') && (github.ref == 'refs/heads/v1alpha1') }}
         run: |
           docker load -i image.tar
           docker inspect ${OPERATOR_IMAGE}

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -108,40 +108,40 @@ jobs:
           kubectl wait --for=condition=Ready pod --all -n kepler-operator-system --timeout 1m
           echo "Operator ready ..."
                
-  push-image:
-    name: Push operator container image to quay.io/sustainable_computing_io/kepler-operator
-    needs: [build-operator,e2e]
-    runs-on: ubuntu-latest
-    steps: 
+  # push-image:
+  #   name: Push operator container image to quay.io/sustainable_computing_io/kepler-operator
+  #   needs: [build-operator,e2e]
+  #   runs-on: ubuntu-latest
+  #   steps: 
       
-      - name: Login to quay.io/sustainable_computing_io/
-        uses: docker/login-action@v1
+  #     - name: Login to quay.io/sustainable_computing_io/
+  #       uses: docker/login-action@v1
 
-        with:
-          registry: quay.io/sustainable_computing_io
-          username: ${{ secrets.BOT_NAME }}
-          password: ${{ secrets.BOT_TOKEN }}
+  #       with:
+  #         registry: quay.io/sustainable_computing_io
+  #         username: ${{ secrets.BOT_NAME }}
+  #         password: ${{ secrets.BOT_TOKEN }}
       
-      - name: Download image bundle
-        uses: actions/download-artifact@v3
-        with:
-          name: kepler-operator
+  #     - name: Download image bundle
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: kepler-operator
 
-      - name: Test artifact download
-        run : |
-          ls -R
-          pwd
+  #     - name: Test artifact download
+  #       run : |
+  #         ls -R
+  #         pwd
 
-      - name: Push to quay
-        run: |
-          docker load -i image.tar
-          docker inspect ${OPERATOR_IMAGE}
-          docker tag ${OPERATOR_IMAGE} ${OPERATOR_IMAGE}:latest
-          docker push ${OPERATOR_IMAGE}:latest 
+  #     - name: Push to quay
+  #       run: |
+  #         docker load -i image.tar
+  #         docker inspect ${OPERATOR_IMAGE}
+  #         docker tag ${OPERATOR_IMAGE} ${OPERATOR_IMAGE}:latest
+  #         docker push ${OPERATOR_IMAGE}:latest 
 
   e2e-success:
     name: Successful e2e tests
-    needs: [build-operator , e2e, push-image]
+    needs: [build-operator , e2e]
     runs-on: ubuntu-latest
     steps:
       - name: Successful


### PR DESCRIPTION
This PR moves creates two workflows. 
- intergration.yaml : to build and e2e test the operator on kind
- image.yaml will make and push image to quay on `push` instead of `pull_request` 

Signed-off-by: Parul <parsingh@redhat.com>