### PR TITLE
Update Naming Convention for Kubernetes Objects

### DIFF
--- a/controllers/kepler_controller.go
+++ b/controllers/kepler_controller.go
@@ -324,8 +324,8 @@ func (r *collectorReconciler) ensureServiceAccount(l klog.Logger) (bool, error) 
 			Kind: "ServiceAccount",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.Instance.Name + "-sa",
-			Namespace: r.Instance.Namespace,
+			Name:      r.Instance.Name + ServiceAccountNameSuffix,
+			Namespace: r.Instance.Namespace + ServiceAccountNameSpaceSuffix,
 		},
 	}
 	kepDesc := keplerSADescription{
@@ -340,8 +340,8 @@ func (r *collectorReconciler) ensureServiceAccount(l klog.Logger) (bool, error) 
 
 func (r *collectorReconciler) ensureConfigMap(l klog.Logger) (bool, error) {
 	cmName := types.NamespacedName{
-		Name:      r.Instance.Name + "-exporter-cfm",
-		Namespace: r.Instance.Namespace,
+		Name:      r.Instance.Name + CollectorConfigMapNameSuffix,
+		Namespace: r.Instance.Namespace + CollectorConfigMapNameSpaceSuffix,
 	}
 	logger := l.WithValues("configmap", cmName)
 	r.configMap = &corev1.ConfigMap{
@@ -386,8 +386,8 @@ func (r *collectorReconciler) ensureConfigMap(l klog.Logger) (bool, error) {
 
 func (r *collectorReconciler) ensureDaemonSet(l klog.Logger) (bool, error) {
 	dsName := types.NamespacedName{
-		Name:      r.Instance.Name + "-exporter",
-		Namespace: r.Instance.Namespace,
+		Name:      r.Instance.Name + DaemonSetNameSuffix,
+		Namespace: r.Instance.Namespace + DaemonSetNameSpaceSuffix,
 	}
 	logger := l.WithValues("daemonSet", dsName)
 	r.daemonSet = &appsv1.DaemonSet{
@@ -422,7 +422,7 @@ func (r *collectorReconciler) ensureDaemonSet(l klog.Logger) (bool, error) {
 		r.daemonSet.Spec.Template.Spec.HostNetwork = true
 		r.daemonSet.Spec.Template.Spec.ServiceAccountName = r.serviceAccount.Name
 		r.daemonSet.Spec.Template.Spec.Containers = []corev1.Container{{
-			Name: "kepler-exporter",
+			Name: "kepler-exporter", //?
 			SecurityContext: &corev1.SecurityContext{
 				Privileged: &scc_value,
 			},
@@ -509,15 +509,15 @@ func (r *collectorReconciler) ensureDaemonSet(l klog.Logger) (bool, error) {
 					ConfigMap: &corev1.ConfigMapVolumeSource{
 						LocalObjectReference: corev1.LocalObjectReference{
 							//Name: "kepler-exporter-cfm",
-							Name: r.Instance.Name + "-exporter-cfm",
+							Name: r.Instance.Name + CollectorConfigMapNameSuffix,
 						},
 					}}},
 		}
 		var matchLabels = make(map[string]string)
 
-		matchLabels["app.kubernetes.io/component"] = "exporter"
-		matchLabels["app.kubernetes.io/name"] = "kepler-exporter"
-		matchLabels["sustainable-computing.io/app"] = "kepler"
+		matchLabels["app.kubernetes.io/component"] = "exporter"   //?
+		matchLabels["app.kubernetes.io/name"] = "kepler-exporter" //?
+		matchLabels["sustainable-computing.io/app"] = "kepler"    //?
 
 		r.daemonSet.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: matchLabels,
@@ -542,8 +542,8 @@ func (r *collectorReconciler) ensureDaemonSet(l klog.Logger) (bool, error) {
 func (r *collectorReconciler) ensureService(l logr.Logger) (bool, error) {
 
 	serviceName := types.NamespacedName{
-		Name:      r.Instance.Name + "-exporter",
-		Namespace: r.Instance.Namespace,
+		Name:      r.Instance.Name + ServiceNameSuffix,
+		Namespace: r.Instance.Namespace + ServiceNameSpaceSuffix,
 	}
 	logger := l.WithValues("Service", serviceName)
 	r.service = &corev1.Service{
@@ -567,14 +567,14 @@ func (r *collectorReconciler) ensureService(l logr.Logger) (bool, error) {
 		if r.service.ObjectMeta.Labels == nil {
 			r.service.ObjectMeta.Labels = map[string]string{}
 		}
-		r.service.ObjectMeta.Labels["app.kubernetes.io/component"] = "exporter"
-		r.service.ObjectMeta.Labels["app.kubernetes.io/name"] = "kepler-exporter"
+		r.service.ObjectMeta.Labels["app.kubernetes.io/component"] = "exporter"   //?
+		r.service.ObjectMeta.Labels["app.kubernetes.io/name"] = "kepler-exporter" //?
 		r.service.Spec.ClusterIP = "None"
 		if r.service.Spec.Selector == nil {
 			r.service.Spec.Selector = map[string]string{}
 		}
-		r.service.Spec.Selector["app.kubernetes.io/component"] = "exporter"
-		r.service.Spec.Selector["app.kubernetes.io/name"] = "kepler-exporter"
+		r.service.Spec.Selector["app.kubernetes.io/component"] = "exporter"   //?
+		r.service.Spec.Selector["app.kubernetes.io/name"] = "kepler-exporter" //?
 
 		r.service.Spec.Ports = []corev1.ServicePort{
 			{

--- a/controllers/kepler_controller.go
+++ b/controllers/kepler_controller.go
@@ -422,7 +422,7 @@ func (r *collectorReconciler) ensureDaemonSet(l klog.Logger) (bool, error) {
 		r.daemonSet.Spec.Template.Spec.HostNetwork = true
 		r.daemonSet.Spec.Template.Spec.ServiceAccountName = r.serviceAccount.Name
 		r.daemonSet.Spec.Template.Spec.Containers = []corev1.Container{{
-			Name: "kepler-exporter", //?
+			Name: "kepler-exporter",
 			SecurityContext: &corev1.SecurityContext{
 				Privileged: &scc_value,
 			},
@@ -515,9 +515,9 @@ func (r *collectorReconciler) ensureDaemonSet(l klog.Logger) (bool, error) {
 		}
 		var matchLabels = make(map[string]string)
 
-		matchLabels["app.kubernetes.io/component"] = "exporter"   //?
-		matchLabels["app.kubernetes.io/name"] = "kepler-exporter" //?
-		matchLabels["sustainable-computing.io/app"] = "kepler"    //?
+		matchLabels["app.kubernetes.io/component"] = "exporter"
+		matchLabels["app.kubernetes.io/name"] = "kepler-exporter"
+		matchLabels["sustainable-computing.io/app"] = "kepler"
 
 		r.daemonSet.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: matchLabels,
@@ -567,14 +567,14 @@ func (r *collectorReconciler) ensureService(l logr.Logger) (bool, error) {
 		if r.service.ObjectMeta.Labels == nil {
 			r.service.ObjectMeta.Labels = map[string]string{}
 		}
-		r.service.ObjectMeta.Labels["app.kubernetes.io/component"] = "exporter"   //?
-		r.service.ObjectMeta.Labels["app.kubernetes.io/name"] = "kepler-exporter" //?
+		r.service.ObjectMeta.Labels["app.kubernetes.io/component"] = "exporter"
+		r.service.ObjectMeta.Labels["app.kubernetes.io/name"] = "kepler-exporter"
 		r.service.Spec.ClusterIP = "None"
 		if r.service.Spec.Selector == nil {
 			r.service.Spec.Selector = map[string]string{}
 		}
-		r.service.Spec.Selector["app.kubernetes.io/component"] = "exporter"   //?
-		r.service.Spec.Selector["app.kubernetes.io/name"] = "kepler-exporter" //?
+		r.service.Spec.Selector["app.kubernetes.io/component"] = "exporter"
+		r.service.Spec.Selector["app.kubernetes.io/name"] = "kepler-exporter"
 
 		r.service.Spec.Ports = []corev1.ServicePort{
 			{

--- a/controllers/kepler_controller_unit_test.go
+++ b/controllers/kepler_controller_unit_test.go
@@ -31,32 +31,32 @@ import (
 )
 
 const (
-	DaemonSetName                          = KeplerOperatorName + "-exporter"
-	ServiceName                            = KeplerOperatorName + "-exporter"
-	KeplerOperatorName                     = "kepler"
-	KeplerOperatorNameSpace                = ""
-	ServiceAccountName                     = KeplerOperatorName + "-sa"
-	ServiceAccountNameSpace                = KeplerOperatorNameSpace
-	ClusterRoleName                        = "kepler-clusterrole"
-	ClusterRoleNameSpace                   = ""
-	ClusterRoleBindingName                 = "kepler-clusterrole-binding"
-	ClusterRoleBindingNameSpace            = ""
-	DaemonSetNameSpace                     = KeplerOperatorNameSpace
-	ServiceNameSpace                       = KeplerOperatorNameSpace
-	CollectorConfigMapName                 = KeplerOperatorName + "-exporter-cfm"
-	CollectorConfigMapNameSpace            = KeplerOperatorNameSpace
-	SCCObjectName                          = "kepler-scc"
-	SCCObjectNameSpace                     = KeplerOperatorNameSpace
-	MachineConfigCGroupKernelArgMasterName = "50-master-cgroupv2"
-	MachineConfigCGroupKernelArgWorkerName = "50-worker-cgroupv2"
-	MachineConfigDevelMasterName           = "51-master-kernel-devel"
-	MachineConfigDevelWorkerName           = "51-worker-kernel-devel"
+	DaemonSetName                          = KeplerOperatorName + DaemonSetNameSuffix
+	ServiceName                            = KeplerOperatorName + ServiceNameSuffix
+	KeplerOperatorName                     = "kepler" //Sample name
+	KeplerOperatorNameSpace                = ""       // Set to default
+	ServiceAccountName                     = KeplerOperatorName + ServiceAccountNameSuffix
+	ServiceAccountNameSpace                = KeplerOperatorNameSpace + ServiceAccountNameSpaceSuffix
+	ClusterRoleName                        = ClusterRoleNameSuffix
+	ClusterRoleNameSpace                   = ClusterRoleNameSpaceSuffix
+	ClusterRoleBindingName                 = ClusterRoleBindingNameSuffix
+	ClusterRoleBindingNameSpace            = ClusterRoleBindingNameSpaceSuffix
+	DaemonSetNameSpace                     = KeplerOperatorNameSpace + DaemonSetNameSpaceSuffix
+	ServiceNameSpace                       = KeplerOperatorNameSpace + ServiceNameSpaceSuffix
+	CollectorConfigMapName                 = KeplerOperatorName + CollectorConfigMapNameSuffix
+	CollectorConfigMapNameSpace            = KeplerOperatorNameSpace + CollectorConfigMapNameSpaceSuffix
+	SCCObjectName                          = SCCObjectNameSuffix
+	SCCObjectNameSpace                     = SCCObjectNameSpaceSuffix
+	MachineConfigCGroupKernelArgMasterName = MachineConfigCGroupKernelArgMasterNameSuffix
+	MachineConfigCGroupKernelArgWorkerName = MachineConfigCGroupKernelArgWorkerNameSuffix
+	MachineConfigDevelMasterName           = MachineConfigDevelMasterNameSuffix
+	MachineConfigDevelWorkerName           = MachineConfigDevelWorkerNameSuffix
 )
 
 func generateDefaultOperatorSettings() (context.Context, *KeplerReconciler, *keplersystemv1alpha1.Kepler, logr.Logger, client.Client) {
 	ctx := context.Background()
 	_ = log.FromContext(ctx)
-	logger := log.Log.WithValues("kepler", types.NamespacedName{Name: "kepler-operator", Namespace: "kepler"})
+	logger := log.Log.WithValues("kepler", types.NamespacedName{Name: KeplerOperatorName, Namespace: KeplerOperatorNameSpace})
 
 	keplerInstance := &keplersystemv1alpha1.Kepler{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/kepler_naming_conventions.go
+++ b/controllers/kepler_naming_conventions.go
@@ -1,0 +1,34 @@
+package controllers
+
+// List of Suffix Names for generated Kepler Kubernetes Objects.
+// Suffix Names may be a concatenation of Kepler Instance and Suffix Name or Suffix Name only.
+
+const (
+	DaemonSetNameSuffix                               = "-exporter"
+	ServiceNameSuffix                                 = "-exporter"
+	DaemonSetNameSpaceSuffix                          = ""
+	ServiceNameSpaceSuffix                            = ""
+	ServiceAccountNameSuffix                          = "-sa"
+	ServiceAccountNameSpaceSuffix                     = ""
+	ClusterRoleNameSuffix                             = "kepler-clusterrole"
+	ClusterRoleNameSpaceSuffix                        = ""
+	ClusterRoleBindingNameSuffix                      = "kepler-clusterrole-binding"
+	ClusterRoleBindingNameSpaceSuffix                 = ""
+	CollectorConfigMapNameSuffix                      = "-exporter-cfm"
+	CollectorConfigMapNameSpaceSuffix                 = ""
+	SCCObjectNameSuffix                               = "kepler-scc"
+	SCCObjectNameSpaceSuffix                          = ""
+	MachineConfigCGroupKernelArgMasterNameSuffix      = "50-master-cgroupv2"
+	MachineConfigCGroupKernelArgWorkerNameSuffix      = "50-worker-cgroupv2"
+	MachineConfigDevelMasterNameSuffix                = "51-master-kernel-devel"
+	MachineConfigDevelWorkerNameSuffix                = "51-worker-kernel-devel"
+	MachineConfigCGroupKernelArgMasterNameSpaceSuffix = ""
+	MachineConfigCGroupKernelArgWorkerNameSpaceSuffix = ""
+	MachineConfigDevelMasterNameSpaceSuffix           = ""
+	MachineConfigDevelWorkerNameSpaceSuffix           = ""
+	PersistentVolumeName                              = "kepler-model-server-pv"
+	PersistentVolumeClaimName                         = "kepler-model-server-pvc"
+	ModelServerConfigMapName                          = "kepler-model-server-cfm"
+	ModelServerServiceName                            = "kepler-model-server"
+	ModelServerDeploymentName                         = "kepler-model-server"
+)

--- a/controllers/machineconfig_controller.go
+++ b/controllers/machineconfig_controller.go
@@ -44,8 +44,9 @@ func (r *collectorReconciler) ensureMachineConfig(l klog.Logger) (bool, error) {
 			APIVersion: "machineconfiguration.openshift.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "50-master-cgroupv2",
-			Labels: master_labels_map,
+			Name:      MachineConfigCGroupKernelArgMasterNameSuffix,
+			Namespace: MachineConfigCGroupKernelArgMasterNameSpaceSuffix,
+			Labels:    master_labels_map,
 		},
 		Spec: mcfgv1.MachineConfigSpec{
 			KernelArguments: []string{"systemd.unified_cgroup_hierarchy=1", "cgroup_no_v1='all'"},
@@ -53,7 +54,7 @@ func (r *collectorReconciler) ensureMachineConfig(l klog.Logger) (bool, error) {
 	}
 
 	found := &mcfgv1.MachineConfig{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "50-master-cgroupv2", Namespace: ""}, found)
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: MachineConfigCGroupKernelArgMasterNameSuffix, Namespace: MachineConfigCGroupKernelArgMasterNameSpaceSuffix}, found)
 	if err != nil {
 		if strings.Contains(err.Error(), "no matches for kind") {
 			fmt.Printf("resulting error not a timeout: %s", err)
@@ -80,15 +81,16 @@ func (r *collectorReconciler) ensureMachineConfig(l klog.Logger) (bool, error) {
 			APIVersion: "machineconfiguration.openshift.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "50-worker-cgroupv2",
-			Labels: worker_labels_map,
+			Name:      MachineConfigCGroupKernelArgWorkerNameSuffix,
+			Namespace: MachineConfigCGroupKernelArgWorkerNameSpaceSuffix,
+			Labels:    worker_labels_map,
 		},
 		Spec: mcfgv1.MachineConfigSpec{
 			KernelArguments: []string{"systemd.unified_cgroup_hierarchy=1", "cgroup_no_v1='all'"},
 		},
 	}
 
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: "50-worker-cgroupv2", Namespace: ""}, found)
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: MachineConfigCGroupKernelArgWorkerNameSuffix, Namespace: MachineConfigCGroupKernelArgWorkerNameSpaceSuffix}, found)
 
 	if err != nil && !apierrors.IsNotFound(err) {
 
@@ -108,15 +110,16 @@ func (r *collectorReconciler) ensureMachineConfig(l klog.Logger) (bool, error) {
 			APIVersion: "machineconfiguration.openshift.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "51-master-kernel-devel",
-			Labels: master_labels_map,
+			Name:      MachineConfigDevelMasterNameSuffix,
+			Namespace: MachineConfigDevelMasterNameSpaceSuffix,
+			Labels:    master_labels_map,
 		},
 		Spec: mcfgv1.MachineConfigSpec{
 			Extensions: []string{"kernel-devel"},
 		},
 	}
 
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: "51-master-kernel-devel", Namespace: ""}, found)
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: MachineConfigDevelMasterNameSuffix, Namespace: MachineConfigDevelMasterNameSpaceSuffix}, found)
 
 	if err != nil && !apierrors.IsNotFound(err) {
 
@@ -136,15 +139,16 @@ func (r *collectorReconciler) ensureMachineConfig(l klog.Logger) (bool, error) {
 			APIVersion: "machineconfiguration.openshift.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "51-worker-kernel-devel",
-			Labels: worker_labels_map,
+			Name:      MachineConfigDevelWorkerNameSuffix,
+			Namespace: MachineConfigDevelWorkerNameSpaceSuffix,
+			Labels:    worker_labels_map,
 		},
 		Spec: mcfgv1.MachineConfigSpec{
 			Extensions: []string{"kernel-devel"},
 		},
 	}
 
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: "51-worker-kernel-devel", Namespace: ""}, found)
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: MachineConfigDevelWorkerNameSuffix, Namespace: MachineConfigDevelWorkerNameSpaceSuffix}, found)
 
 	if err != nil && !apierrors.IsNotFound(err) {
 

--- a/controllers/model_server_handler.go
+++ b/controllers/model_server_handler.go
@@ -20,14 +20,6 @@ import (
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const (
-	PersistentVolumeName      = "kepler-model-server-pv"
-	PersistentVolumeClaimName = "kepler-model-server-pvc"
-	ModelServerConfigMapName  = "kepler-model-server-cfm"
-	ModelServerServiceName    = "kepler-model-server"
-	ModelServerDeploymentName = "kepler-model-server"
-)
-
 type ModelServerDeployment struct {
 	Context               context.Context
 	Instance              *keplerv1alpha1.Kepler

--- a/controllers/sahandler.go
+++ b/controllers/sahandler.go
@@ -58,7 +58,8 @@ func (d *keplerSADescription) ensureRole(l klog.Logger) (bool, error) {
 			Kind: "ClusterRole",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "kepler-clusterrole",
+			Name:      ClusterRoleNameSuffix,
+			Namespace: ClusterRoleNameSpaceSuffix,
 		},
 	}
 
@@ -78,13 +79,14 @@ func (d *keplerSADescription) ensureRoleBinding(l klog.Logger) (bool, error) {
 			Kind: "ClusterRoleBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "kepler-clusterrole-binding",
+			Name:      ClusterRoleBindingNameSuffix,
+			Namespace: ClusterRoleBindingNameSpaceSuffix,
 		},
 	}
 	d.clusterRoleBinding.RoleRef = rbacv1.RoleRef{
 		APIGroup: "rbac.authorization.k8s.io",
 		Kind:     "ClusterRole",
-		Name:     "kepler-clusterrole",
+		Name:     ClusterRoleNameSuffix,
 	}
 	d.clusterRoleBinding.Subjects = []rbacv1.Subject{
 		{
@@ -97,7 +99,7 @@ func (d *keplerSADescription) ensureRoleBinding(l klog.Logger) (bool, error) {
 	logger := l.WithValues("RoleBinding", nameFor(d.clusterRoleBinding))
 
 	found := &rbacv1.ClusterRoleBinding{}
-	err := d.Client.Get(context.TODO(), types.NamespacedName{Name: "kepler-clusterrole-binding", Namespace: ""}, found)
+	err := d.Client.Get(context.TODO(), types.NamespacedName{Name: ClusterRoleBindingNameSuffix, Namespace: ClusterRoleBindingNameSpaceSuffix}, found)
 
 	if err != nil && !apierrors.IsNotFound(err) {
 		return false, err
@@ -122,7 +124,8 @@ func (d *keplerSADescription) createOrUpdateClusterRole(l klog.Logger) (*rbacv1.
 
 	d.clusterRole = &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "kepler-clusterrole",
+			Name:      ClusterRoleNameSuffix,
+			Namespace: ClusterRoleNameSpaceSuffix,
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -135,7 +138,7 @@ func (d *keplerSADescription) createOrUpdateClusterRole(l klog.Logger) (*rbacv1.
 
 	logger := l.WithValues("kepler-clusterrole", d.clusterRole.ObjectMeta.Name)
 	found := &rbacv1.ClusterRole{}
-	err := d.Client.Get(context.TODO(), types.NamespacedName{Name: "kepler-clusterrole", Namespace: ""}, found)
+	err := d.Client.Get(context.TODO(), types.NamespacedName{Name: ClusterRoleNameSuffix, Namespace: ClusterRoleNameSpaceSuffix}, found)
 
 	if err != nil && !apierrors.IsNotFound(err) {
 

--- a/controllers/scc_controller.go
+++ b/controllers/scc_controller.go
@@ -42,9 +42,10 @@ func (r *collectorReconciler) ensureSCC(l klog.Logger) (bool, error) {
 			APIVersion: "security.openshift.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kepler-scc",
+			//Name:      "kepler-scc",
+			Name:      SCCObjectNameSuffix,
 			Labels:    labels,
-			Namespace: r.Instance.Namespace,
+			Namespace: r.Instance.Namespace + SCCObjectNameSpaceSuffix,
 		},
 		AllowPrivilegedContainer: true,
 		AllowHostDirVolumePlugin: true,
@@ -62,14 +63,15 @@ func (r *collectorReconciler) ensureSCC(l klog.Logger) (bool, error) {
 		},
 		SELinuxContext: securityv1.SELinuxContextStrategyOptions{
 			Type: securityv1.SELinuxStrategyRunAsAny,
-		},
-		Users:   []string{"kepler", "system:serviceaccount:" + r.Instance.Namespace + ":kepler-sa"},
+		}, //?
+		//Users:   []string{"kepler", "system:serviceaccount:" + r.Instance.Namespace + ":kepler-sa"},
+		Users:   []string{r.Instance.Name, "system:serviceaccount:" + r.Instance.Namespace + ":" + r.Instance.Name + ServiceAccountNameSuffix},
 		Volumes: []securityv1.FSType{securityv1.FSType("configMap"), securityv1.FSType("projected"), securityv1.FSType("emptyDir"), securityv1.FSType("hostPath")},
 	}
 
 	found := &securityv1.SecurityContextConstraints{}
 
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "kepler-scc", Namespace: r.Instance.Namespace}, found)
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: SCCObjectNameSuffix, Namespace: r.Instance.Namespace + SCCObjectNameSpaceSuffix}, found)
 	if err != nil {
 		if strings.Contains(err.Error(), "no matches for kind") {
 			fmt.Printf("resulting error not a timeout: %s", err)

--- a/controllers/scc_controller.go
+++ b/controllers/scc_controller.go
@@ -64,8 +64,8 @@ func (r *collectorReconciler) ensureSCC(l klog.Logger) (bool, error) {
 		SELinuxContext: securityv1.SELinuxContextStrategyOptions{
 			Type: securityv1.SELinuxStrategyRunAsAny,
 		}, //?
-		Users: []string{"kepler", "system:serviceaccount:" + r.Instance.Namespace + ":kepler-sa"},
-		//Users:   []string{r.Instance.Name, "system:serviceaccount:" + r.Instance.Namespace + ":" + r.Instance.Name + ServiceAccountNameSuffix},
+		//Users: []string{"kepler", "system:serviceaccount:" + r.Instance.Namespace + ":kepler-sa"},
+		Users:   []string{"kepler", "system:serviceaccount:" + r.Instance.Namespace + ":" + r.Instance.Name + ServiceAccountNameSuffix},
 		Volumes: []securityv1.FSType{securityv1.FSType("configMap"), securityv1.FSType("projected"), securityv1.FSType("emptyDir"), securityv1.FSType("hostPath")},
 	}
 

--- a/controllers/scc_controller.go
+++ b/controllers/scc_controller.go
@@ -64,8 +64,8 @@ func (r *collectorReconciler) ensureSCC(l klog.Logger) (bool, error) {
 		SELinuxContext: securityv1.SELinuxContextStrategyOptions{
 			Type: securityv1.SELinuxStrategyRunAsAny,
 		}, //?
-		//Users:   []string{"kepler", "system:serviceaccount:" + r.Instance.Namespace + ":kepler-sa"},
-		Users:   []string{r.Instance.Name, "system:serviceaccount:" + r.Instance.Namespace + ":" + r.Instance.Name + ServiceAccountNameSuffix},
+		Users: []string{"kepler", "system:serviceaccount:" + r.Instance.Namespace + ":kepler-sa"},
+		//Users:   []string{r.Instance.Name, "system:serviceaccount:" + r.Instance.Namespace + ":" + r.Instance.Name + ServiceAccountNameSuffix},
 		Volumes: []securityv1.FSType{securityv1.FSType("configMap"), securityv1.FSType("projected"), securityv1.FSType("emptyDir"), securityv1.FSType("hostPath")},
 	}
 

--- a/controllers/scc_controller.go
+++ b/controllers/scc_controller.go
@@ -63,7 +63,7 @@ func (r *collectorReconciler) ensureSCC(l klog.Logger) (bool, error) {
 		},
 		SELinuxContext: securityv1.SELinuxContextStrategyOptions{
 			Type: securityv1.SELinuxStrategyRunAsAny,
-		}, //?
+		},
 		//Users: []string{"kepler", "system:serviceaccount:" + r.Instance.Namespace + ":kepler-sa"},
 		Users:   []string{"kepler", "system:serviceaccount:" + r.Instance.Namespace + ":" + r.Instance.Name + ServiceAccountNameSuffix},
 		Volumes: []securityv1.FSType{securityv1.FSType("configMap"), securityv1.FSType("projected"), securityv1.FSType("emptyDir"), securityv1.FSType("hostPath")},


### PR DESCRIPTION
This update includes defining a list of constants for defining kepler objects name and namespaces. The defined constants are the suffixes since kubernetes objects can include kepler object's name and namespace as the prefix. 