### PR TITLE
Added support for VSCode Dev Containers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+// Development environment for Kepler Operator Project
+// README at: https://github.com/devcontainers/templates/tree/main/src/go
+{
+	"name": "Go",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/go:0-1-bullseye",
+	"features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+			"version": "latest",
+			"helm": "latest",
+			"minikube": "none"
+		},
+		"ghcr.io/mpriscella/features/kind:1": {
+			"version": "latest"
+		},
+		"ghcr.io/rio/features/kustomize:1": {}
+	},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-azuretools.vscode-docker",
+				"ms-kubernetes-tools.vscode-kubernetes-tools",
+				"redhat.vscode-yaml",
+				"yzhang.markdown-all-in-one",
+				"bierner.markdown-preview-github-styles",
+				"davidanson.vscode-markdownlint",
+				"donjayamanne.githistory",
+				"GitHub.vscode-pull-request-github"
+			]
+		}
+	},
+
+	"postCreateCommand": "bash .devcontainer/scripts/install-tools.sh"
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+}

--- a/.devcontainer/scripts/install-tools.sh
+++ b/.devcontainer/scripts/install-tools.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+######################################################################
+# These scripts are meant to be run in user mode as they may modify
+# usr settings line .bashrc and .bash_aliases
+######################################################################
+
+echo "**********************************************************************"
+echo "Install OpenShift CLI..."
+echo "**********************************************************************"
+if [ $(uname -m) == aarch64 ]; then
+    echo "Installing OpenShift CLI for ARM64..."
+    curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux-arm64.tar.gz --output oc.tar.gz
+else
+    echo "Installing OpenShift CLI for x86_64..."
+    curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz --output oc.tar.gz
+fi;
+sudo tar xvzf oc.tar.gz -C /usr/local/bin/ oc
+sudo ln -s /usr/local/bin/oc /usr/bin/oc
+rm oc.tar.gz
+oc version
+
+echo "**********************************************************************"
+echo "Creatine alias for kubectl (kc) and kustomize (ku)..."
+echo "**********************************************************************"
+
+echo "Creating kc and kns alias for kubectl..."
+echo "alias kc='/usr/local/bin/kubectl'" >> $HOME/.bash_aliases
+echo "alias kns='kubectl config set-context --current --namespace'" >> $HOME/.bash_aliases
+echo "Creating ku alias for kustomize..."
+echo "alias ku='/usr/local/bin/kustomize'" >> $HOME/.bash_aliases
+
+echo "Extra tools installations complete."

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ _output/*
 *.swo
 *~
 .vscode/
+
+# Operating system metadata files
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You’ll need a Kubernetes cluster to run against. You can use [KIND](https://si
 
 ### Automated development environment
 
-If don't have a `go` developmnt environment, or you just want a reproducible environment to start fresh, you can use [Docker Desktop](https://www.docker.com/products/docker-desktop/), [Visual Studio Code](https://code.visualstudio.com), and the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension to bring up an environment with `go`, `docker`, `kind`, `kubectl`, `kustomize`, and `oc` simply by opening this project and pressing the **Reopen in Container** button when prompted. (See the [Developing inside a Container](https://code.visualstudio.com/docs/devcontainers/containers) documentation for more details).
+If don't have a `go` developmnt environment, or you just want a reproducible environment to start fresh, you can use [Docker Desktop](https://www.docker.com/products/docker-desktop/), [Visual Studio Code](https://code.visualstudio.com), and the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension to bring up an environment with `go`, `docker`, `kind`, `kubectl`, `kustomize`, and `oc`. To activate this, open the project from the command line with `code .` and then press the **Reopen in Container** button when prompted. (See the [Developing inside a Container](https://code.visualstudio.com/docs/devcontainers/containers) documentation for more details).
 
 ### Running on the cluster
 1. Install Instances of Custom Resources:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 You’ll need a Kubernetes cluster to run against. You can use [KIND](https://sigs.k8s.io/kind) to get a local cluster for testing, or run against a remote cluster.
 **Note:** Your controller will automatically use the current context in your kubeconfig file (i.e. whatever cluster `kubectl cluster-info` shows).
 
+### Automated development environment
+
+If don't have a `go` developmnt environment, or you just want a reproducible environment to start fresh, you can use [Docker Desktop](https://www.docker.com/products/docker-desktop/), [Visual Studio Code](https://code.visualstudio.com), and the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension to bring up an environment with `go`, `docker`, `kind`, `kubectl`, `kustomize`, and `oc` simply by opening this project and pressing the **Reopen in Container** button when prompted. (See the [Developing inside a Container](https://code.visualstudio.com/docs/devcontainers/containers) documentation for more details).
+
 ### Running on the cluster
 1. Install Instances of Custom Resources:
 


### PR DESCRIPTION
Made the following additions that creates a reproducible go development environment using Docker, Visual Studio Code, and the Dev Containers extension:

- Added a `.devcontainer` folder to configure the VSCode Dev Container extension to provide:
  - go
  - docker-in-docker
  - oc
  - kubectl
  - helm
  - kustomize
  - kind
- Updated the `README.md` to add a paragraph about this new capability 

To activate, open the project with:

```bash
cd kepler-operator
code .
```

Then press the **Reopen in Container** button and a development environment will be created.

<img width="1665" alt="reopen-in-container" src="https://user-images.githubusercontent.com/5069008/219794343-e4ce4158-e98c-4412-a982-49405ffc2a22.png">

