### PR TITLE
remove HostPort that causes conflicts with SNO's CNI over port 9102

### DIFF
--- a/controllers/kepler_controller.go
+++ b/controllers/kepler_controller.go
@@ -427,7 +427,6 @@ func (r *collectorReconciler) ensureDaemonSet(l klog.Logger) (bool, error) {
 		r.daemonSet.Spec.Template.Spec.Tolerations = tolerations
 
 		r.daemonSet.Spec.Template.ObjectMeta.Name = dsName.Name
-		r.daemonSet.Spec.Template.Spec.HostNetwork = true
 		r.daemonSet.Spec.Template.Spec.ServiceAccountName = r.serviceAccount.Name
 
 		image := r.Instance.Spec.Collector.Image
@@ -442,7 +441,6 @@ func (r *collectorReconciler) ensureDaemonSet(l klog.Logger) (bool, error) {
 			Command: []string{"/usr/bin/kepler", "-address", bindAddress, "-enable-gpu=true", "enable-cgroup-id=true", "v=5"},
 			Ports: []corev1.ContainerPort{{
 				ContainerPort: collectorPort,
-				HostPort:      collectorPort,
 				Name:          "http",
 			}},
 		}}

--- a/controllers/kepler_controller_unit_test.go
+++ b/controllers/kepler_controller_unit_test.go
@@ -405,7 +405,6 @@ func testVerifyDaemonSpec(t *testing.T, returnedServiceAccount corev1.ServiceAcc
 	assert.Equal(t, DaemonSetNameSpace, returnedDaemonSet.ObjectMeta.Namespace)
 
 	assert.Equal(t, DaemonSetName, returnedDaemonSet.Spec.Template.ObjectMeta.Name)
-	assert.True(t, returnedDaemonSet.Spec.Template.Spec.HostNetwork)
 	assert.Equal(t, returnedServiceAccount.Name, returnedDaemonSet.Spec.Template.Spec.ServiceAccountName)
 	// check if daemonset obeys general rules
 	//TODO: MATCH LABELS IS subset to labels. SAME WITH SELECTOR IN SERVICE


### PR DESCRIPTION
With Single Node Openshift (and presuambly others) port 9102 is already used by the OVN Kubernetes CNI. Attempting to reuse it caused the kepler-exporter pod to get stuck in 'pending' because it couldn't get the hostport it wanted.  This commit removes the requirement for host networking and HostPort: 9102 from kepler-export, which allows it to run on.

This is the same issue as https://github.com/sustainable-computing-io/kepler/issues/527 and the same fix ported over.