### PR TITLE
Update kustomization

### DIFF
--- a/hack/dashboard/openshift/00-kepler-operator-namespaces.yaml
+++ b/hack/dashboard/openshift/00-kepler-operator-namespaces.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kepler-operator-system

--- a/hack/dashboard/openshift/00-servicemonitoring-kepler.yaml
+++ b/hack/dashboard/openshift/00-servicemonitoring-kepler.yaml
@@ -1,15 +1,46 @@
+# apiVersion: monitoring.coreos.com/v1
+# kind: ServiceMonitor
+# metadata:
+#   labels:
+#     app.kubernetes.io/component: exporter
+#   name: monitor-kepler-exporter
+#   namespace: kepler-operator-system
+# spec:
+#   endpoints:
+#   - interval: 15s
+#     port: http
+#     scheme: http
+#   selector:
+#     matchLabels:
+#       app.kubernetes.io/component: exporter
+
+
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kepler-exporter
+    sustainable-computing.io/app: kepler
   name: monitor-kepler-exporter
-  namespace: kepler-operator-system
+  namespace: openshift-operators
 spec:
   endpoints:
-  - interval: 15s
+  - interval: 3s
     port: http
+    relabelings:
+    - action: replace
+      regex: (.*)
+      replacement: $1
+      sourceLabels:
+      - __meta_kubernetes_pod_node_name
+      targetLabel: instance
     scheme: http
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames:
+    - openshift-operators
   selector:
     matchLabels:
       app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: kepler-exporter

--- a/hack/dashboard/openshift/README.md
+++ b/hack/dashboard/openshift/README.md
@@ -10,3 +10,10 @@ The following cmd will:
 ```bash
 $(pwd)/deploy-grafana.sh
 ```
+
+
+# Test if `kepler-exporter` metrics are scraped by OpenShift user workload monitoring
+
+```bash
+kubectl exec -ti -n openshift-user-workload-monitoring prometheus-user-workload-0 -- bash -c 'curl "localhost:9090/api/v1/query?query=kepler_container_package_joules_total[5s]"' 
+```

--- a/hack/dashboard/openshift/kustomization.yaml
+++ b/hack/dashboard/openshift/kustomization.yaml
@@ -4,5 +4,7 @@ commonLabels:
 
 resources:
 - 00-openshift-monitoring-user-projects.yaml
+- 00-kepler-operator-namespaces.yaml
 - 00-servicemonitoring-kepler.yaml
 - 01-grafana-operator.yaml
+- 05-user-workload-monitoring-config.yaml


### PR DESCRIPTION
This PR updates 
- the `hack/dashboard/openshift/kustomization.yaml` to create `namespace/kepler-operator-system`  for setting up grafana
- moves `servivemonitor/monitor-kepler-exporter` to namespace `openshift-operators` where `kepler-exporter` service is deployed.
- updates README to include scripts for testing if `kepler-exporter` metrics are scraped by OpenShift user workload monitoring