### PR TITLE
Fix error when deploying kepler-operator locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can use the image from [quay.io](https://quay.io/repository/sustainable_comp
 
 ```sh
 make deploy IMG=quay.io/sustainable_computing_io/kepler-operator:latest
-kubectl apply -f config/samples/
+kubectl apply -k config/samples/
 ```
 
 Alternatively, if you like to build and use your own image,
@@ -34,7 +34,7 @@ Alternatively, if you like to build and use your own image,
 ```sh
 make docker-build docker-push IMG=<some-registry>/kepler-operator:tag
 make deploy IMG=<some-registry>/kepler-operator:tag
-kubectl apply -f config/samples/
+kubectl apply -k config/samples/
 ```
 
 ### Uninstall the operator

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 ## Append samples you want in your CSV to this file as resources ##
 resources:
 - kepler.system_v1alpha1_kepler.yaml


### PR DESCRIPTION
When running `kubectl apply -k config/samples/` kubectl throws the following error: 
```
kubectl apply -f config/samples/
kepler.kepler.system.sustainable.computing.io/kepler created
error: resource mapping not found for name: "" namespace: "" from "config/samples/kustomization.yaml": no matches for kind "Kustomization" in version "kustomize.config.k8s.io/v1beta1"
ensure CRDs are installed first
```
Instead of using `kubectl apply -f` we can also use `kubectl apply -k` to avoid running `kustomize build` every time when applying the sample.