### PR TITLE
Improve running operator locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ local-dev-cluster/*
 # Operating system metadata files
 .DS_Store
 Thumbs.db
+
+/tmp

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 ##@ Build Dependencies
 
 ## Location to install dependencies to
-LOCALBIN ?= $(shell pwd)/bin
+LOCALBIN ?= $(shell pwd)/tmp/bin
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 
@@ -266,28 +266,34 @@ set_govulncheck:
 govulncheck: set_govulncheck tidy-vendor
 	@govulncheck -v ./... || true
 	
-cluster-clean: build-manifest
-	./hack/cluster-clean.sh
 .PHONY: cluster-clean
+cluster-clean:
+	./hack/cluster-clean.sh
 
+.PHONY: cluster-deploy
 cluster-deploy: cluster-clean
 	BARE_METAL_NODE_ONLY=false ./hack/cluster-deploy.sh
-.PHONY: cluster-deploy
 
+.PHONY: cluster-sync
 cluster-sync:
 	./hack/cluster-sync.sh
-.PHONY: cluster-sync
 
+.PHONY: prepareKubeConfig
 prepareKubeConfig:
 	./hack/prepareKubeConfig.sh
-.PHONY: prepareKubeConfig
 
-cluster-up:
-	rm -rf local-dev-cluster
-	git clone -b v0.0.1 https://github.com/sustainable-computing-io/local-dev-cluster.git --depth=1
-	cd local-dev-cluster && ./main.sh
 .PHONY: cluster-up
+cluster-up:
+	@{ \
+		set -e ;\
+		mkdir -p tmp ;\
+		cd tmp/ ;\
+		rm -rf local-dev-cluster ;\
+		git clone -b v0.0.1 https://github.com/sustainable-computing-io/local-dev-cluster.git --depth=1 ;\
+		cd local-dev-cluster ;\
+		./main.sh up ;\
+	}
 
+.PHONY: create-bundle
 create-bundle:
 	./hack/bundle.sh
-.PHONY: create-bundle

--- a/README.md
+++ b/README.md
@@ -16,10 +16,20 @@ You’ll need a Kubernetes cluster to run against. You can use [KIND](https://si
 ### To run a kind cluster locally 
 
 ```sh
-make cluster-up CLUSTER_PROVIDER='kind' CI_DEPLOY=true
+make cluster-up
+kind get kubeconfig > tmp/kubeconfig
+export KUBECONFIG="$PWD/tmp/kubeconfig"
 ```
 
-### To run kepler-operator locally on the cluster
+### Run kepler-operator locally out of cluster
+
+```sh
+kubectl apply -k config/crd
+go run . --zap-devel --zap-log-level=100 2>&1 | tee tmp/operator.log
+kubectl apply -k config/samples/
+```
+
+### Run using pre-published image
 
 You can use the image from [quay.io](https://quay.io/repository/sustainable_computing_io/kepler-operator?tab=tags) to deploy kepler-operator. 
 
@@ -28,8 +38,8 @@ make deploy IMG=quay.io/sustainable_computing_io/kepler-operator:latest
 kubectl apply -k config/samples/
 ```
 
-Alternatively, if you like to build and use your own image,
 
+Alternatively, if you like to build and use your own image,
 	
 ```sh
 make docker-build docker-push IMG=<some-registry>/kepler-operator:tag


### PR DESCRIPTION
This PR improves on how operator is run locally by
  1. installing local-dev-cluster to a tmp directory
  2. moving all tools (controller-gen, kustomize etc) to tmp/bin
  3. Adding a section explaining running operator out of cluster