### PR TITLE
Create separate cluster-up.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,15 +284,7 @@ prepareKubeConfig:
 
 .PHONY: cluster-up
 cluster-up:
-	@{ \
-		set -e ;\
-		mkdir -p tmp ;\
-		cd tmp/ ;\
-		rm -rf local-dev-cluster ;\
-		git clone -b v0.0.1 https://github.com/sustainable-computing-io/local-dev-cluster.git --depth=1 ;\
-		cd local-dev-cluster ;\
-		./main.sh up ;\
-	}
+	./hack/cluster-up.sh
 
 .PHONY: create-bundle
 create-bundle:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ These data and stats from cgroup and sysfs can then be fed into ML models to est
 Check out the project on GitHub ➡️ [Kepler](https://github.com/sustainable-computing-io/kepler).
 
 ## Getting Started
-You’ll need a Kubernetes cluster to run against. You can use [KIND](https://sigs.k8s.io/kind) to get a local cluster for testing, or run against a remote cluster.
+You’ll need a Kubernetes/OpenShift cluster to run against. You can use [KIND](https://sigs.k8s.io/kind) or microshift to get a local cluster for testing, or run against a remote cluster.
 **Note:** Your controller will automatically use the current context in your kubeconfig file (i.e. whatever cluster `kubectl cluster-info` shows).
 
 ### To run a kind cluster locally 
@@ -19,6 +19,12 @@ You’ll need a Kubernetes cluster to run against. You can use [KIND](https://si
 make cluster-up
 kind get kubeconfig > tmp/kubeconfig
 export KUBECONFIG="$PWD/tmp/kubeconfig"
+```
+
+### To run a microshift cluster locally
+
+```sh
+make cluster-up CLUSTER_PROVIDER=microshift
 ```
 
 ### Run kepler-operator locally out of cluster

--- a/hack/cluster-up.sh
+++ b/hack/cluster-up.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# This file is part of the Kepler project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 The Kepler Contributors
+#
+
+set -e
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+declare -r PROJECT_ROOT
+declare -r TMP_DIR="$PROJECT_ROOT/tmp"
+declare -r CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kind}
+declare -r VERSION=${VERSION:-v0.0.1}
+
+function main() {
+
+    if [ ! -d "${TMP_DIR}" ]
+    then
+        mkdir "${TMP_DIR}"
+    fi
+
+    cd "${TMP_DIR}"
+
+    if [ -d local-dev-cluster ]
+    then
+        echo "using local local-dev-cluster"
+    else
+        echo "downloading local-dev-cluster with version ${VERSION}"
+        git clone -b "${VERSION}" https://github.com/sustainable-computing-io/local-dev-cluster.git --depth=1
+    fi
+
+    cd local-dev-cluster
+    ./main.sh up
+}
+
+main


### PR DESCRIPTION
This PR:
* Moves the steps to setup cluster from Makefile to `/hack/cluster-up.sh`
* Update README to add steps to set up `microshift` cluster.