### PR TITLE
bump up local-dev-cluster version to 0.0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 ##@ Development env
 CLUSTER_PROVIDER ?= kind
-LOCAL_DEV_CLUSTER_VERSION ?= v0.0.2
+LOCAL_DEV_CLUSTER_VERSION ?= v0.0.3
 GRAFANA_ENABLE ?= true
 
 .PHONY: cluster-up

--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -20,7 +20,7 @@
 set -eu -o pipefail
 
 # config
-declare -r VERSION=${VERSION:-v0.0.2}
+declare -r VERSION=${VERSION:-v0.0.3}
 declare -r CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kind}
 declare -r GRAFANA_ENABLE=${GRAFANA_ENABLE:-true}
 


### PR DESCRIPTION
This PR bump-ups the version of local-dev-cluster to 0.0.3