### PR TITLE
fix gh workflow to use correct path

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -31,12 +31,10 @@ jobs:
 
         - name: Build Operator Image
           run: |
-            chmod +x ./test/run-e2e.sh
-            ./test/run-e2e.sh build
+            ./tests/run-e2e.sh build
 
-        
         - name: Push to quay
           run: |
-            ./test/run-e2e.sh push
+            ./tests/run-e2e.sh push
           
     


### PR DESCRIPTION
This PR fixes the path for running run-e2e.sh in gh workflow. Reference to a [failed](https://github.com/sustainable-computing-io/kepler-operator/actions/runs/5815701708/job/15767681380#step:5:10) CI run