### PR TITLE
ci: validate images can be built with right version pre-merge

### DIFF
--- a/.github/compute-version/action.yaml
+++ b/.github/compute-version/action.yaml
@@ -1,0 +1,16 @@
+name: Compute Version
+description: computes version of the operator
+outputs:
+  version:
+    description: "operator version"
+    value: ${{ steps.version.outputs.version }}
+runs:
+  using: composite
+  steps:
+    - name: Generate Version
+      id: version
+      shell: bash
+      run: |
+        version="$(cat VERSION)-$(date +%Y%m%d%H%M%S)"
+        echo VERSION=$version
+        echo "version=$version" >> $GITHUB_OUTPUT

--- a/.github/publish-images/action.yaml
+++ b/.github/publish-images/action.yaml
@@ -1,0 +1,61 @@
+name: Build and Publish Images
+description: 'Publishes operator and bundle images to an Image Registry'
+inputs:
+  image_registry:
+    description: "image registry"
+    required: true
+  registry_login:
+    description: "registry username"
+    required: true
+  registry_token:
+    description: "registry token"
+    required: true
+
+  version:
+    description: "operator version"
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Checkout source
+      uses: actions/checkout@v3
+
+    - uses: actions/setup-go@main
+      with:
+        go-version-file: go.mod
+        check-latest: true
+        cache: true
+
+    - name: Login to Image Registry 
+      uses: docker/login-action@v2
+      if: "!startsWith(inputs.image_registry, 'localhost')"
+      with:
+        registry: ${{ inputs.image_registry }}
+        username: ${{ inputs.registry_login }}
+        password: ${{ inputs.registry_token }}
+      
+
+    - name: Build Operator
+      shell: bash
+      run: |
+        make operator-build
+      env:
+        VERSION: ${{ inputs.version }}
+        IMG_BASE: ${{ inputs.image_registry }}
+
+    - name: Build Bundle
+      shell: bash
+      run: |
+        make bundle bundle-build
+      env:
+        VERSION: ${{ inputs.version }}
+        IMG_BASE: ${{ inputs.image_registry }}
+
+    - name: Push Images
+      shell: bash
+      if: "!startsWith(inputs.image_registry, 'localhost')"
+      run: |
+        make operator-push  bundle-push
+      env:
+        VERSION: ${{ inputs.version }}
+        IMG_BASE: ${{ inputs.image_registry }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,6 +1,7 @@
 name: images
 
 on:
+  pull_request:
   push:
     branches: [ v1alpha1 ]
 
@@ -15,38 +16,23 @@ jobs:
         - uses: actions/setup-go@main
           with:
             go-version-file: go.mod
+            cache: true
 
-        - name: Login to Quay
-          uses: docker/login-action@v2
-          with:
-            registry: quay.io/sustainable_computing_io
-            username: ${{ secrets.BOT_NAME }}
-            password: ${{ secrets.BOT_TOKEN }}
-
-        - name: Generate Version
+        - uses: ./.github/compute-version
           id: version
-          run: |
-            version="$(cat VERSION)-$(date +%Y%m%d%H%M%S)"
-            echo VERSION=$version
-            echo "version=$version" >> $GITHUB_OUTPUT
 
-        - name: Build Operator
-          run: |
-            make operator-build
-          env:
-            VERSION: ${{ steps.version.outputs.version }}
-            IMG_BASE: ${{ vars.IMG_BASE }}
+        - name: build and publish images to external registry
+          uses: ./.github/publish-images
+          if: github.event_name == 'push'
+          with:
+            image_registry: ${{ vars.IMG_BASE }}
+            registry_login: ${{ secrets.BOT_NAME }}
+            registry_token: ${{ secrets.BOT_TOKEN }}
+            version: ${{ steps.version.outputs.version }}
 
-        - name: Build Bundle
-          run: |
-            make bundle bundle-build
-          env:
-            VERSION: ${{ steps.version.outputs.version }}
-            IMG_BASE: ${{ vars.IMG_BASE }}
-
-        - name: Push Images
-          run: |
-            make operator-push  bundle-push
-          env:
-            VERSION: ${{ steps.version.outputs.version }}
-            IMG_BASE: ${{ vars.IMG_BASE }}
+        - name: build images for PR checks
+          uses: ./.github/publish-images
+          if: github.event_name != 'push'
+          with:
+            image_registry: "localhost:5001"
+            version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -17,10 +17,13 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
+
       - name: Install Go
         uses: actions/setup-go@main
         with:
           go-version-file: go.mod
+          cache: true
+
       - name: Install all tools
         run: make tools
       - name: use kepler action for kind cluster build
@@ -30,8 +33,16 @@ jobs:
           runningBranch: kind
       - name: Ensure cluster is able to run OLM bundles
         run: make cluster-prereqs
+
+      - uses: ./.github/compute-version
+        id: version
+
       - name: Run e2e tests
-        run: ./tests/run-e2e.sh --ci
+        run: |
+          ./tests/run-e2e.sh --ci
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+
   e2e-success:
     name: Successful e2e tests
     needs: [e2e]


### PR DESCRIPTION

This patch validates that the images can be built and that the bundle
is validated by
  * refactoring version computation
  * refactoring image builds to a separate action that is reused

Signed-off-by: Sunil Thaha <sthaha@redhat.com>
