### PR TITLE
Update kepler cm

### DIFF
--- a/pkg/components/exporter/exporter.go
+++ b/pkg/components/exporter/exporter.go
@@ -132,10 +132,11 @@ func NewDaemonSet(detail components.Detail, k *v1alpha1.Kepler) *appsv1.DaemonSe
 						Command: []string{
 							"/usr/bin/kepler",
 							"-address", bindAddress,
-							"-enable-gpu=true",
+							"-enable-gpu=$(ENABLE_GPU)",
 							"-enable-cgroup-id=true",
-							"-v=1",
+							"-v=$(KEPLER_LOG_LEVEL)",
 							"-kernel-source-dir=/usr/share/kepler/kernel_sources",
+							"-redfish-cred-file-path=/etc/redfish/redfish.csv",
 						},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: int32(exporter.Port),
@@ -156,7 +157,9 @@ func NewDaemonSet(detail components.Detail, k *v1alpha1.Kepler) *appsv1.DaemonSe
 							TimeoutSeconds:      10},
 						Env: []corev1.EnvVar{
 							{Name: "NODE_IP", ValueFrom: k8s.EnvFromField("status.hostIP")},
-							{Name: "NODE_NAME", ValueFrom: k8s.EnvFromField("spec.nodeName")}},
+							{Name: "NODE_NAME", ValueFrom: k8s.EnvFromField("spec.nodeName")},
+							{Name: "KEPLER_LOG_LEVEL", ValueFrom: k8s.EnvFromConfigMap("KEPLER_LOG_LEVEL", ConfigmapName)},
+							{Name: "ENABLE_GPU", ValueFrom: k8s.EnvFromConfigMap("ENABLE_GPU", ConfigmapName)}},
 						VolumeMounts: []corev1.VolumeMount{
 							{Name: "lib-modules", MountPath: "/lib/modules"},
 							{Name: "tracing", MountPath: "/sys"},
@@ -211,7 +214,7 @@ func NewConfigMap(d components.Detail, k *v1alpha1.Kepler) *corev1.ConfigMap {
 		},
 		Data: map[string]string{
 			"KEPLER_NAMESPACE":                  components.Namespace,
-			"KEPLER_LOG_LEVEL":                  "5",
+			"KEPLER_LOG_LEVEL":                  "1",
 			"METRIC_PATH":                       "/metrics",
 			"BIND_ADDRESS":                      bindAddress,
 			"ENABLE_GPU":                        "true",

--- a/pkg/components/exporter/exporter.go
+++ b/pkg/components/exporter/exporter.go
@@ -210,20 +210,23 @@ func NewConfigMap(d components.Detail, k *v1alpha1.Kepler) *corev1.ConfigMap {
 			Labels:    labels,
 		},
 		Data: map[string]string{
-			// TODO: decide what this should be
-			"KEPLER_NAMESPACE":     components.Namespace,
-			"KEPLER_LOG_LEVEL":     "5",
-			"METRIC_PATH":          "/metrics",
-			"BIND_ADDRESS":         bindAddress,
-			"ENABLE_GPU":           "true",
-			"ENABLE_EBPF_CGROUPID": "true",
-			"CPU_ARCH_OVERRIDE":    "",
-			"CGROUP_METRICS":       "*",
-			// TODO: clean this long time
-			"MODEL_CONFIG": "| CONTAINER_COMPONENTS_ESTIMATOR=false CONTAINER_COMPONENTS_INIT_URL=https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-server/main/tests/test_models/DynComponentModelWeight/CgroupOnly/ScikitMixed/ScikitMixed.json",
-
-			"EXPOSE_HW_COUNTER_METRICS": "true",
-			"EXPOSE_CGROUP_METRICS":     "true",
+			"KEPLER_NAMESPACE":                  components.Namespace,
+			"KEPLER_LOG_LEVEL":                  "5",
+			"METRIC_PATH":                       "/metrics",
+			"BIND_ADDRESS":                      bindAddress,
+			"ENABLE_GPU":                        "true",
+			"ENABLE_QAT":                        "false",
+			"ENABLE_EBPF_CGROUPID":              "true",
+			"EXPOSE_HW_COUNTER_METRICS":         "true",
+			"EXPOSE_IRQ_COUNTER_METRICS":        "true",
+			"EXPOSE_KUBELET_METRICS":            "true",
+			"EXPOSE_CGROUP_METRICS":             "true",
+			"ENABLE_PROCESS_METRICS":            "false",
+			"CPU_ARCH_OVERRIDE":                 "",
+			"CGROUP_METRICS":                    "*",
+			"REDFISH_PROBE_INTERVAL_IN_SECONDS": "60",
+			"REDFISH_SKIP_SSL_VERIFY":           "true",
+			"MODEL_CONFIG":                      "CONTAINER_COMPONENTS_ESTIMATOR=false",
 		},
 	}
 }

--- a/pkg/utils/k8s/k8s.go
+++ b/pkg/utils/k8s/k8s.go
@@ -81,6 +81,17 @@ func EnvFromField(path string) *corev1.EnvVarSource {
 	}
 }
 
+func EnvFromConfigMap(key, cmName string) *corev1.EnvVarSource {
+	return &corev1.EnvVarSource{
+		ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+			Key: key,
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: cmName,
+			},
+		},
+	}
+}
+
 func GVKName(o client.Object) string {
 	ns := o.GetNamespace()
 	name := o.GetName()


### PR DESCRIPTION
This PR 
- updates `kepler-exporter-cm` to sync with latest config of kepler. as per [kepler repo manifest](https://github.com/sustainable-computing-io/kepler/blob/main/manifests/config/exporter/exporter.yaml#L11-L34)
- fixes kepler command line args in kepler daemon set to use values from  `kepler-exporter-cm` 

fixes: #111 

