### PR TITLE
feat: enable monitoring of kepler-operator

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           cluster_provider: kind
           runningBranch: kind
+        env:
+          PROMETHEUS_ENABLE: "true"
+
       - name: Ensure cluster is able to run OLM bundles
         run: make cluster-prereqs
 

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -42,3 +42,22 @@ jobs:
           ./tests/run-e2e.sh --ci
         env:
           VERSION: ${{ steps.version.outputs.version }}
+
+      - name: Capture cluster state
+        if: always()
+        shell: bash
+        run: |
+          # Capture apiserver state
+          # TODO: enable this when we have oc installed as part of `make tools`
+          # oc adm inspect node --dest-dir cluster-state || true
+          # oc adm inspect -A statefulset --dest-dir cluster-state || true
+          # oc adm inspect -A deployment --dest-dir cluster-state || true
+          # oc adm inspect -A ns --dest-dir cluster-state || true
+          cp -r tmp/e2e cluster-state/ || true
+
+      - name: Archive production artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: cluster-state
+          path: cluster-state

--- a/bundle/manifests/kepler-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/kepler-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/created-by: kepler-operator
+    app.kubernetes.io/instance: controller-manager-metrics-monitor
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: servicemonitor
+    app.kubernetes.io/part-of: kepler-operator
+    control-plane: controller-manager
+  name: kepler-operator-controller-manager-metrics-monitor
+spec:
+  endpoints:
+  - port: metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: service
+      app.kubernetes.io/part-of: kepler-operator
+      control-plane: controller-manager

--- a/bundle/manifests/kepler-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/kepler-operator-controller-manager-metrics-service_v1_service.yaml
@@ -13,10 +13,10 @@ metadata:
   name: kepler-operator-controller-manager-metrics-service
 spec:
   ports:
-  - name: https
-    port: 8443
+  - name: metrics
+    port: 8080
     protocol: TCP
-    targetPort: https
+    targetPort: metrics
   selector:
     control-plane: controller-manager
 status:

--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.6.2
-    createdAt: "2023-08-30T07:38:54Z"
+    createdAt: "2023-09-04T08:38:00Z"
     description: 'Deploys and Manages Kepler on Kubernetes '
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -190,51 +190,10 @@ spec:
               labels:
                 control-plane: controller-manager
             spec:
-              affinity:
-                nodeAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    nodeSelectorTerms:
-                    - matchExpressions:
-                      - key: kubernetes.io/arch
-                        operator: In
-                        values:
-                        - amd64
-                        - arm64
-                        - ppc64le
-                        - s390x
-                      - key: kubernetes.io/os
-                        operator: In
-                        values:
-                        - linux
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                  protocol: TCP
-                resources:
-                  limits:
-                    cpu: 500m
-                    memory: 128Mi
-                  requests:
-                    cpu: 5m
-                    memory: 64Mi
-                securityContext:
-                  allowPrivilegeEscalation: false
-                  capabilities:
-                    drop:
-                    - ALL
-              - args:
-                - --health-probe-bind-address=:8081
-                - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
-                - --zap-log-level=3
+                - --zap-log-level=5
                 command:
                 - /manager
                 image: quay.io/sustainable_computing_io/kepler-operator:0.6.2
@@ -246,6 +205,10 @@ spec:
                   initialDelaySeconds: 15
                   periodSeconds: 20
                 name: manager
+                ports:
+                - containerPort: 8080
+                  name: metrics
+                  protocol: TCP
                 readinessProbe:
                   httpGet:
                     path: /readyz

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -22,13 +22,13 @@ bases:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../prometheus
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+# - manager_auth_proxy_patch.yaml
 
 
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,6 +70,7 @@ spec:
         - /manager
         args:
         - --leader-elect
+        - --zap-log-level=5
         image: '<OPERATOR_IMG>'
         imagePullPolicy: IfNotPresent
         name: manager
@@ -99,5 +100,9 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+          name: metrics
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -15,12 +15,9 @@ metadata:
   namespace: system
 spec:
   endpoints:
-    - path: /metrics
-      port: https
-      scheme: https
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tlsConfig:
-        insecureSkipVerify: true
+    - port: metrics
   selector:
     matchLabels:
+      app.kubernetes.io/name: service
+      app.kubernetes.io/part-of: kepler-operator
       control-plane: controller-manager

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -13,9 +13,9 @@ metadata:
   namespace: system
 spec:
   ports:
-  - name: https
-    port: 8443
+  - name: metrics
+    port: 8080
     protocol: TCP
-    targetPort: https
+    targetPort: metrics
   selector:
     control-plane: controller-manager


### PR DESCRIPTION
This patch removes the kube-rbac-proxy so that metrics of the operator
can be scrapped without any auth(z). It additionally adds a service
monitor to the bundle so that the operator can be monitored if User
Project Monitoring is enabled in the OpenShift cluster.

Fixes: https://github.com/sustainable-computing-io/kepler-operator/issues/145

Signed-off-by: Sunil Thaha <sthaha@redhat.com>
