### PR TITLE
fix: removed old topk(10) namespace panel

### DIFF
--- a/hack/dashboard/assets/dashboard.json
+++ b/hack/dashboard/assets/dashboard.json
@@ -23,7 +23,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": 2,
-  "iteration": 1693934809617,
+  "iteration": 1694154532971,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -40,72 +40,6 @@
       "panels": [],
       "title": "Power Consumption",
       "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 1
-      },
-      "id": 15,
-      "options": {
-        "displayMode": "gradient",
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true
-      },
-      "pluginVersion": "8.5.5",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "topk(10, sum by (container_namespace) (\n  (increase(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n)\n+\nsum by (container_namespace) (\n  (increase(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n))",
-          "interval": "",
-          "legendFormat": "{{container_namespace}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Total Power Consumption (PKG+DRAM) for Namespace: $namespace or Top 10 Namespaces if ALL Namespaces is selected (kWh per day)",
-      "type": "bargauge"
     },
     {
       "datasource": {
@@ -171,7 +105,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 1
       },
       "id": 18,
       "options": {
@@ -350,7 +284,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 13
       },
       "id": 16,
       "options": {
@@ -540,7 +474,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 30
+        "y": 23
       },
       "id": 2,
       "options": {
@@ -734,7 +668,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 30
+        "y": 23
       },
       "id": 17,
       "options": {
@@ -835,7 +769,7 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "openshift-kepler-operator",
           "value": "openshift-kepler-operator"
         },
@@ -913,7 +847,7 @@
   "timepicker": {},
   "timezone": "browser",
   "title": "Kepler Exporter Dashboard",
-  "uid": "125cb5f5fdbea19c3067b2b34e897ad5d2b40a51",
+  "uid": "381ef848417532a1ef945494449453a41fdabaa7",
   "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
This PR removes the old `topk(10)` namespaces panel which was left for review in earlier PR #208 

new dashboard starts with
![image](https://github.com/sustainable-computing-io/kepler-operator/assets/3284044/50e5864e-e5fc-4689-a951-902570d618ac)
