### PR TITLE
DNM: fix: change increase() to irate() in topk(10) namespace panel

### DIFF
--- a/hack/dashboard/assets/dashboard.json
+++ b/hack/dashboard/assets/dashboard.json
@@ -22,8 +22,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2,
-  "iteration": 1694154532971,
+  "id": 4,
+  "iteration": 1694158358708,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -132,7 +132,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum by (container_namespace) (\n  (increase(kepler_container_package_joules_total{container_namespace=~\".*\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_package_joules_total{container_namespace=~\".*\"}[24h])/\n    count_over_time(kepler_container_package_joules_total{container_namespace=~\".*\"}[1h])\n  )\n)\n+\nsum by (container_namespace) (\n  (increase(kepler_container_dram_joules_total{container_namespace=~\".*\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_dram_joules_total{container_namespace=~\".*\"}[24h])/\n    count_over_time(kepler_container_dram_joules_total{container_namespace=~\".*\"}[1h])\n  )\n))",
+          "expr": "topk(10, sum by (container_namespace) (\n  (irate(kepler_container_package_joules_total{container_namespace=~\".*\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_package_joules_total{container_namespace=~\".*\"}[24h])/\n    count_over_time(kepler_container_package_joules_total{container_namespace=~\".*\"}[1h])\n  )\n)\n+\nsum by (container_namespace) (\n  (irate(kepler_container_dram_joules_total{container_namespace=~\".*\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_dram_joules_total{container_namespace=~\".*\"}[24h])/\n    count_over_time(kepler_container_dram_joules_total{container_namespace=~\".*\"}[1h])\n  )\n))",
           "format": "table",
           "interval": "",
           "legendFormat": "{{container_namespace}}",


### PR DESCRIPTION
the `topk(10)` namespace panel uses `increase()` function. so the query gives increase in the joules over a period of 24 hours, and not watts as expected.
changed the `increase()` function to `irate()`  to get watts and then convert watts to kwh



kwh values with `increase()`:
![image](https://github.com/sustainable-computing-io/kepler-operator/assets/3284044/cf385393-924c-4eef-826f-fecb0a344031)



kwh values with `irate()`:
![image](https://github.com/sustainable-computing-io/kepler-operator/assets/3284044/a88bd0e5-29d9-4627-a579-04788f2a04e6)
