### PR TITLE
feat: update grafana dashboard

### DIFF
--- a/hack/dashboard/assets/kepler/dashboard.json
+++ b/hack/dashboard/assets/kepler/dashboard.json
@@ -23,10 +23,95 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": 2,
-  "iteration": 1694154532971,
+  "iteration": 1694196150140,
   "links": [],
   "liveNow": false,
   "panels": [
+    {
+      "description": "",
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 0
+      },
+      "id": 20,
+      "options": {
+        "content": "<h1 style=\"text-align: center;\">${cpu_architecture}</h1>",
+        "mode": "markdown"
+      },
+      "pluginVersion": "8.5.5",
+      "title": "CPU- Architecture",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 3,
+        "y": 0
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["last"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.5.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(kepler_node_info)",
+          "instant": false,
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Kepler Pods",
+      "type": "stat"
+    },
     {
       "collapsed": false,
       "datasource": "prometheus",
@@ -34,7 +119,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 4
       },
       "id": 8,
       "panels": [],
@@ -52,12 +137,6 @@
           "color": {
             "mode": "thresholds"
           },
-          "custom": {
-            "align": "auto",
-            "displayMode": "auto",
-            "filterable": true,
-            "inspect": false
-          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -65,64 +144,32 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
           "unit": "kwatth"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value (lastNotNull)"
-            },
-            "properties": [
-              {
-                "id": "custom.displayMode",
-                "value": "gradient-gauge"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "container_namespace"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 300
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 1
+        "y": 5
       },
       "id": 18,
       "options": {
-        "footer": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
           "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
+          "limit": 10,
+          "values": true
         },
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": true,
-            "displayName": "Value (lastNotNull)"
-          }
-        ]
+        "showUnfilled": true
       },
       "pluginVersion": "8.5.5",
       "targets": [
@@ -147,9 +194,7 @@
           "options": {
             "fields": {
               "Value": {
-                "aggregations": [
-                  "lastNotNull"
-                ],
+                "aggregations": ["lastNotNull"],
                 "operation": "aggregate"
               },
               "container_namespace": {
@@ -158,9 +203,21 @@
               }
             }
           }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Value (lastNotNull)"
+              }
+            ]
+          }
         }
       ],
-      "type": "table"
+      "type": "bargauge"
     },
     {
       "datasource": {
@@ -174,11 +231,11 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisLabel": "watt",
+            "axisLabel": "",
             "axisPlacement": "left",
             "barAlignment": 0,
-            "drawStyle": "bars",
-            "fillOpacity": 44,
+            "drawStyle": "line",
+            "fillOpacity": 0,
             "gradientMode": "opacity",
             "hideFrom": {
               "graph": false,
@@ -187,16 +244,16 @@
               "viz": false
             },
             "lineInterpolation": "linear",
-            "lineWidth": 0,
+            "lineWidth": 2,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "always",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -215,7 +272,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "watt"
         },
         "overrides": [
           {
@@ -284,14 +342,12 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 17
       },
       "id": 16,
       "options": {
         "legend": {
-          "calcs": [
-            "mean"
-          ],
+          "calcs": ["lastNotNull"],
           "displayMode": "table",
           "placement": "right",
           "sortBy": "Mean",
@@ -306,9 +362,9 @@
         {
           "datasource": "prometheus",
           "editorMode": "code",
-          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_package_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
+          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_package_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[5m]))",
           "hide": false,
-          "interval": "",
+          "interval": "5m",
           "legendFormat": "{{pod_name}} / {{container_namespace}} / PKG",
           "range": true,
           "refId": "A"
@@ -316,9 +372,9 @@
         {
           "datasource": "prometheus",
           "editorMode": "code",
-          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_dram_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
+          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_dram_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[5m]))",
           "hide": false,
-          "interval": "",
+          "interval": "5m",
           "legendFormat": "{{pod_name}} / {{container_namespace}} / DRAM",
           "range": true,
           "refId": "B"
@@ -329,9 +385,9 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
+          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[5m]))",
           "hide": false,
-          "interval": "",
+          "interval": "5m",
           "legendFormat": "{{pod_name}} / {{container_namespace}} / OTHER",
           "range": true,
           "refId": "C"
@@ -342,8 +398,9 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
+          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[5m]))",
           "hide": false,
+          "interval": "5m",
           "legendFormat": "{{pod_name}} / {{container_namespace}} / GPU",
           "range": true,
           "refId": "D"
@@ -364,11 +421,11 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisLabel": "watt",
+            "axisLabel": "",
             "axisPlacement": "left",
             "barAlignment": 0,
-            "drawStyle": "bars",
-            "fillOpacity": 44,
+            "drawStyle": "line",
+            "fillOpacity": 11,
             "gradientMode": "opacity",
             "hideFrom": {
               "graph": false,
@@ -377,16 +434,16 @@
               "viz": false
             },
             "lineInterpolation": "linear",
-            "lineWidth": 0,
+            "lineWidth": 2,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "always",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -405,7 +462,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "watt"
         },
         "overrides": [
           {
@@ -474,20 +532,17 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 23
+        "y": 27
       },
       "id": 2,
       "options": {
         "legend": {
-          "calcs": [
-            "mean",
-            "max"
-          ],
+          "calcs": ["mean", "max"],
           "displayMode": "table",
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single",
+          "mode": "multi",
           "sort": "none"
         }
       },
@@ -498,9 +553,9 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum(irate(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1m])))",
+          "expr": "topk(10, sum(irate(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[5m])))",
           "hide": false,
-          "interval": "",
+          "interval": "5m",
           "legendFormat": "PKG",
           "range": true,
           "refId": "A"
@@ -511,9 +566,9 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum(irate(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1m])))",
+          "expr": "topk(10, sum(irate(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[5m])))",
           "hide": false,
-          "interval": "",
+          "interval": "5m",
           "legendFormat": "DRAM",
           "range": true,
           "refId": "B"
@@ -524,8 +579,9 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10,sum(irate(kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\"}[1m])))",
+          "expr": "topk(10,sum(irate(kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\"}[5m])))",
           "hide": false,
+          "interval": "5m",
           "legendFormat": "OTHER",
           "range": true,
           "refId": "C"
@@ -536,8 +592,9 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum(irate(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[1m])))",
+          "expr": "topk(10, sum(irate(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[5m])))",
           "hide": false,
+          "interval": "5m",
           "legendFormat": " GPU",
           "range": true,
           "refId": "D"
@@ -558,11 +615,11 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisLabel": "kWh",
+            "axisLabel": "",
             "axisPlacement": "left",
             "barAlignment": 0,
-            "drawStyle": "bars",
-            "fillOpacity": 44,
+            "drawStyle": "line",
+            "fillOpacity": 11,
             "gradientMode": "opacity",
             "hideFrom": {
               "graph": false,
@@ -571,16 +628,16 @@
               "viz": false
             },
             "lineInterpolation": "linear",
-            "lineWidth": 0,
+            "lineWidth": 2,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "always",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -599,7 +656,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "kwatth"
         },
         "overrides": [
           {
@@ -668,22 +726,19 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 23
+        "y": 27
       },
       "id": 17,
       "options": {
         "legend": {
-          "calcs": [
-            "mean",
-            "max"
-          ],
+          "calcs": ["mean", "max"],
           "displayMode": "table",
           "placement": "bottom",
           "sortBy": "Max",
           "sortDesc": true
         },
         "tooltip": {
-          "mode": "single",
+          "mode": "multi",
           "sort": "none"
         }
       },
@@ -696,7 +751,7 @@
           "editorMode": "code",
           "expr": "topk(10, sum(\n  (increase(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n))",
           "hide": false,
-          "interval": "",
+          "interval": "5m",
           "legendFormat": "PKG (CORE+UNCORE)",
           "range": true,
           "refId": "A"
@@ -709,7 +764,7 @@
           "editorMode": "code",
           "expr": "topk(10, sum(\n  (increase(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n))",
           "hide": false,
-          "interval": "",
+          "interval": "5m",
           "legendFormat": "DRAM",
           "range": true,
           "refId": "B"
@@ -722,6 +777,7 @@
           "editorMode": "code",
           "expr": "topk(10, sum(\n  (increase(\n    kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(\n    kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(\n      kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n))",
           "hide": false,
+          "interval": "5m",
           "legendFormat": "OTHER",
           "range": true,
           "refId": "C"
@@ -734,6 +790,7 @@
           "editorMode": "code",
           "expr": "topk(10, sum(\n  (increase(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n))",
           "hide": false,
+          "interval": "5m",
           "legendFormat": " GPU",
           "range": true,
           "refId": "D"
@@ -837,6 +894,28 @@
         "query": "0.000000277777777777778",
         "skipUrlSync": false,
         "type": "constant"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(kepler_node_info,cpu_architecture)",
+        "description": "fetch the type of cpu-architecture from kepler_node_info metric",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "cpu_architecture",
+        "options": [],
+        "query": {
+          "query": "label_values(kepler_node_info,cpu_architecture)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
       }
     ]
   },

--- a/hack/dashboard/assets/kepler/dashboard.json
+++ b/hack/dashboard/assets/kepler/dashboard.json
@@ -28,27 +28,169 @@
   "liveNow": false,
   "panels": [
     {
-      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "List of different CPU architecture with number of nodes",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "center",
+            "displayMode": "auto",
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
       "gridPos": {
-        "h": 4,
-        "w": 3,
+        "h": 7,
+        "w": 6,
         "x": 0,
         "y": 0
       },
-      "id": 20,
+      "id": 29,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "kepler_node_nodeInfo",
+          "url": "https://github.com/sustainable-computing-io/kepler-doc/blob/84e3e01a0110829937cd40f9634dd8d0c92540a4/docs/design/metrics.md#kepler-metrics-for-node-information"
+        }
+      ],
       "options": {
-        "content": "<h1 style=\"text-align: center;\">${cpu_architecture}</h1>",
-        "mode": "markdown"
+        "footer": {
+          "enablePagination": true,
+          "fields": ["Value"],
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
       },
       "pluginVersion": "8.5.5",
-      "title": "CPU- Architecture",
-      "type": "text"
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (cpu_architecture)(kepler_node_info)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Architecture",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Number of Nodes",
+              "cpu_architecture": "Architecture"
+            }
+          }
+        }
+      ],
+      "type": "table"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "description": "Total energy consumption of the host. (kWh per day)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "kwatth"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 3,
+        "x": 6,
+        "y": 0
+      },
+      "id": 25,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "kepler_node_platform_joules_total",
+          "url": "https://github.com/sustainable-computing-io/kepler-doc/blob/84e3e01a0110829937cd40f9634dd8d0c92540a4/docs/design/metrics.md#kepler-metrics-for-node-energy-consumption"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "value"
+      },
+      "pluginVersion": "8.5.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (source) (\n    (\n      sum by (source) (\n        increase(kepler_node_platform_joules_total[1h])\n      ) * $watt_per_second_to_kWh\n    ) * (\n      sum by (source) (\n        count_over_time(kepler_node_platform_joules_total[24h])\n      ) / sum by (source) (\n        count_over_time(kepler_node_platform_joules_total[1h])\n      )\n    )\n  )",
+          "hide": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Energy Consumption ($source)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Total number of Kepler pods up and running",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -76,15 +218,15 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 7,
         "w": 3,
-        "x": 3,
+        "x": 9,
         "y": 0
       },
       "id": 22,
       "options": {
         "colorMode": "value",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
@@ -119,7 +261,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 4
+        "y": 7
       },
       "id": 8,
       "panels": [],
@@ -131,7 +273,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "",
+      "description": "Total Power Consumption for Top 10 Namespaces (kWh per day)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -155,9 +297,16 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 8
       },
       "id": 18,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "kepler_container_packages_joules_total",
+          "url": "https://github.com/sustainable-computing-io/kepler-doc/blob/84e3e01a0110829937cd40f9634dd8d0c92540a4/docs/design/metrics.md#kepler-metrics-for-container-energy-consumption"
+        }
+      ],
       "options": {
         "displayMode": "gradient",
         "minVizHeight": 10,
@@ -179,7 +328,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum by (container_namespace) (\n  (increase(kepler_container_package_joules_total{container_namespace=~\".*\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_package_joules_total{container_namespace=~\".*\"}[24h])/\n    count_over_time(kepler_container_package_joules_total{container_namespace=~\".*\"}[1h])\n  )\n)\n+\nsum by (container_namespace) (\n  (increase(kepler_container_dram_joules_total{container_namespace=~\".*\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_dram_joules_total{container_namespace=~\".*\"}[24h])/\n    count_over_time(kepler_container_dram_joules_total{container_namespace=~\".*\"}[1h])\n  )\n))",
+          "expr": "topk(10,\n  sum by (container_namespace) (\n    (\n      sum by (container_namespace) (\n        increase(kepler_container_package_joules_total{container_namespace=~\".*\"}[1h])\n      ) * $watt_per_second_to_kWh\n    ) * (\n      sum by (container_namespace) (\n        count_over_time(kepler_container_package_joules_total{container_namespace=~\".*\"}[24h])\n      ) / sum by (container_namespace) (\n        count_over_time(kepler_container_package_joules_total{container_namespace=~\".*\"}[1h])\n      )\n    )\n    +\n    (\n      sum by (container_namespace) (\n        increase(kepler_container_dram_joules_total{container_namespace=~\".*\"}[1h])\n      ) * $watt_per_second_to_kWh\n    ) * (\n      sum by (container_namespace) (\n        count_over_time(kepler_container_dram_joules_total{container_namespace=~\".*\"}[24h])\n      ) / sum by (container_namespace) (\n        count_over_time(kepler_container_dram_joules_total{container_namespace=~\".*\"}[1h])\n      )\n    )\n  )\n)\n",
           "format": "table",
           "interval": "",
           "legendFormat": "{{container_namespace}}",
@@ -187,7 +336,7 @@
           "refId": "A"
         }
       ],
-      "title": "Total Power Consumption (PKG+DRAM) for Top 10 Namespaces (kWh per day)",
+      "title": "Total Power Consumption (PKG+DRAM) for Top 10 Namespaces",
       "transformations": [
         {
           "id": "groupBy",
@@ -224,7 +373,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "",
+      "description": "Cumulative energy consumed by the CPU socket, including all cores and uncore components (e.g. last-level cache, integrated GPU and memory controller).\n",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -266,16 +415,411 @@
               {
                 "color": "green",
                 "value": null
-              },
+              }
+            ]
+          },
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 16,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "kepler_container_package_joules_total",
+          "url": "https://github.com/sustainable-computing-io/kepler-doc/blob/84e3e01a0110829937cd40f9634dd8d0c92540a4/docs/design/metrics.md#kepler-metrics-for-container-energy-consumption"
+        }
+      ],
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "prometheus",
+          "editorMode": "code",
+          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_package_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[5m]))",
+          "hide": false,
+          "interval": "5m",
+          "legendFormat": "{{pod_name}} / {{container_namespace}} / PKG",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pod/Process (PKG) Power Consumption (W) in Namespace: $namespace",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "The total energy spent in DRAM by a container.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
               {
-                "color": "red",
-                "value": 80
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 23,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "kepler_container_dram_joules_total",
+          "url": "https://github.com/sustainable-computing-io/kepler-doc/blob/84e3e01a0110829937cd40f9634dd8d0c92540a4/docs/design/metrics.md#kepler-metrics-for-container-energy-consumption"
+        }
+      ],
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "prometheus",
+          "editorMode": "code",
+          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_dram_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[5m]))",
+          "hide": false,
+          "interval": "5m",
+          "legendFormat": "{{pod_name}} / {{container_namespace}} / DRAM",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Pod/Process (DRAM) Power Consumption (W) in Namespace: $namespace",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Cumulative energy consumption on other host components besides the CPU and DRAM",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "id": 26,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "kepler_container_other_joules_total",
+          "url": "https://github.com/sustainable-computing-io/kepler-doc/blob/84e3e01a0110829937cd40f9634dd8d0c92540a4/docs/design/metrics.md#kepler-metrics-for-container-energy-consumption"
+        }
+      ],
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "prometheus",
+          "editorMode": "code",
+          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_other_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[5m]))",
+          "hide": false,
+          "interval": "5m",
+          "legendFormat": "{{pod_name}} / {{container_namespace}} / OTHER",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pod/Process (OTHER) Power Consumption (W) in Namespace: $namespace",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Total energy consumption on the GPU that a certain container has used.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "id": 27,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "kepler_container_gpu_joules_total",
+          "url": "https://github.com/sustainable-computing-io/kepler-doc/blob/84e3e01a0110829937cd40f9634dd8d0c92540a4/docs/design/metrics.md#kepler-metrics-for-container-energy-consumption"
+        }
+      ],
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "prometheus",
+          "editorMode": "code",
+          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[5m]))",
+          "hide": false,
+          "interval": "5m",
+          "legendFormat": "{{pod_name}} / {{container_namespace}} / GPU",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pod/Process (GPU) Power Consumption (W) in Namespace: $namespace",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Power Consumption (W) of Top10 processes in Namespace or Top 10 Namespace if ALL namespaces is selected",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 11,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
               }
             ]
           },
           "unit": "watt"
         },
         "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*PKG.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
           {
             "matcher": {
               "id": "byRegexp",
@@ -320,211 +864,6 @@
                 }
               }
             ]
-          },
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": ".*PKG.*"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 17
-      },
-      "id": 16,
-      "options": {
-        "legend": {
-          "calcs": ["lastNotNull"],
-          "displayMode": "table",
-          "placement": "right",
-          "sortBy": "Mean",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": "prometheus",
-          "editorMode": "code",
-          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_package_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[5m]))",
-          "hide": false,
-          "interval": "5m",
-          "legendFormat": "{{pod_name}} / {{container_namespace}} / PKG",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": "prometheus",
-          "editorMode": "code",
-          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_dram_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[5m]))",
-          "hide": false,
-          "interval": "5m",
-          "legendFormat": "{{pod_name}} / {{container_namespace}} / DRAM",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[5m]))",
-          "hide": false,
-          "interval": "5m",
-          "legendFormat": "{{pod_name}} / {{container_namespace}} / OTHER",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[5m]))",
-          "hide": false,
-          "interval": "5m",
-          "legendFormat": "{{pod_name}} / {{container_namespace}} / GPU",
-          "range": true,
-          "refId": "D"
-        }
-      ],
-      "title": "Pod/Process Power Consumption (W) in Namespace: $namespace",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "left",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 11,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "watt"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": ".*Package.*"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": ".*DRAM.*"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "orange",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": ".*OtherComponents.*"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": ".*GPU.*"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "semi-dark-green",
-                  "mode": "fixed"
-                }
-              }
-            ]
           }
         ]
       },
@@ -532,7 +871,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 27
+        "y": 40
       },
       "id": 2,
       "options": {
@@ -579,7 +918,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10,sum(irate(kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\"}[5m])))",
+          "expr": "topk(10,sum(irate(kepler_container_other_joules_total{container_namespace=~\"$namespace\"}[5m])))",
           "hide": false,
           "interval": "5m",
           "legendFormat": "OTHER",
@@ -600,7 +939,7 @@
           "refId": "D"
         }
       ],
-      "title": "Power Consumption (W) of Top10 processes in Namespace: $namespace or Top 10 Namespace if ALL namespaces is selected",
+      "title": "Power Consumption (W) of Top10 processes in Namespace: $namespace",
       "type": "timeseries"
     },
     {
@@ -608,7 +947,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "",
+      "description": "Total Power Consumption (kWh per day) of Top10 processes in Namespace or Top10 Namespace if All Namespaces selected",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -650,10 +989,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
@@ -663,7 +998,7 @@
           {
             "matcher": {
               "id": "byRegexp",
-              "options": ".*Package.*"
+              "options": ".*PKG.*"
             },
             "properties": [
               {
@@ -693,7 +1028,7 @@
           {
             "matcher": {
               "id": "byRegexp",
-              "options": ".*OtherComponents.*"
+              "options": ".*OTHER.*"
             },
             "properties": [
               {
@@ -726,7 +1061,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 27
+        "y": 40
       },
       "id": 17,
       "options": {
@@ -775,7 +1110,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum(\n  (increase(\n    kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(\n    kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(\n      kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n))",
+          "expr": "topk(10, sum(\n  (increase(\n    kepler_container_other_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(\n    kepler_container_other_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(\n      kepler_container_other_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n))",
           "hide": false,
           "interval": "5m",
           "legendFormat": "OTHER",
@@ -796,7 +1131,7 @@
           "refId": "D"
         }
       ],
-      "title": "Total Power Consumption (kWh per day) of Top10 processes in Namespace: $namespace or Top10 Namesapces if All Namespaces selected",
+      "title": "Total Power Consumption (kWh per day) of Top10 processes in Namespace: $namespace",
       "type": "timeseries"
     }
   ],
@@ -867,6 +1202,7 @@
           "uid": "${datasource}"
         },
         "definition": "label_values(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}, pod_name)",
+        "description": "Number of pods inside namespace",
         "hide": 0,
         "includeAll": true,
         "label": "Pod",
@@ -900,15 +1236,15 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(kepler_node_info,cpu_architecture)",
-        "description": "fetch the type of cpu-architecture from kepler_node_info metric",
+        "definition": "label_values(kepler_node_platform_joules_total,source)",
+        "description": "Source Type",
         "hide": 2,
         "includeAll": false,
         "multi": false,
-        "name": "cpu_architecture",
+        "name": "source",
         "options": [],
         "query": {
-          "query": "label_values(kepler_node_info,cpu_architecture)",
+          "query": "label_values(kepler_node_platform_joules_total,source)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/hack/dashboard/assets/kepler/dashboard.json
+++ b/hack/dashboard/assets/kepler/dashboard.json
@@ -379,390 +379,6 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Cumulative energy consumed by the CPU socket, including all cores and uncore components (e.g. last-level cache, integrated GPU and memory controller).\n",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "left",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "watt"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 12,
-        "x": 0,
-        "y": 19
-      },
-      "id": 16,
-      "links": [
-        {
-          "targetBlank": true,
-          "title": "kepler_container_package_joules_total",
-          "url": "https://github.com/sustainable-computing-io/kepler-doc/blob/84e3e01a0110829937cd40f9634dd8d0c92540a4/docs/design/metrics.md#kepler-metrics-for-container-energy-consumption"
-        }
-      ],
-      "options": {
-        "legend": {
-          "calcs": ["lastNotNull"],
-          "displayMode": "table",
-          "placement": "right",
-          "sortBy": "Mean",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": "prometheus",
-          "editorMode": "code",
-          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_package_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[5m]))",
-          "hide": false,
-          "interval": "5m",
-          "legendFormat": "{{pod_name}} / {{container_namespace}} / PKG",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Pod/Process (PKG) Power Consumption (W) in Namespace: $namespace",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "The total energy spent in DRAM by a container.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "left",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "watt"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 12,
-        "x": 12,
-        "y": 19
-      },
-      "id": 23,
-      "links": [
-        {
-          "targetBlank": true,
-          "title": "kepler_container_dram_joules_total",
-          "url": "https://github.com/sustainable-computing-io/kepler-doc/blob/84e3e01a0110829937cd40f9634dd8d0c92540a4/docs/design/metrics.md#kepler-metrics-for-container-energy-consumption"
-        }
-      ],
-      "options": {
-        "legend": {
-          "calcs": ["lastNotNull"],
-          "displayMode": "table",
-          "placement": "right",
-          "sortBy": "Mean",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": "prometheus",
-          "editorMode": "code",
-          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_dram_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[5m]))",
-          "hide": false,
-          "interval": "5m",
-          "legendFormat": "{{pod_name}} / {{container_namespace}} / DRAM",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Pod/Process (DRAM) Power Consumption (W) in Namespace: $namespace",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Cumulative energy consumption on other host components besides the CPU and DRAM",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "left",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "watt"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 12,
-        "x": 0,
-        "y": 29
-      },
-      "id": 26,
-      "links": [
-        {
-          "targetBlank": true,
-          "title": "kepler_container_other_joules_total",
-          "url": "https://github.com/sustainable-computing-io/kepler-doc/blob/84e3e01a0110829937cd40f9634dd8d0c92540a4/docs/design/metrics.md#kepler-metrics-for-container-energy-consumption"
-        }
-      ],
-      "options": {
-        "legend": {
-          "calcs": ["lastNotNull"],
-          "displayMode": "table",
-          "placement": "right",
-          "sortBy": "Mean",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": "prometheus",
-          "editorMode": "code",
-          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_other_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[5m]))",
-          "hide": false,
-          "interval": "5m",
-          "legendFormat": "{{pod_name}} / {{container_namespace}} / OTHER",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Pod/Process (OTHER) Power Consumption (W) in Namespace: $namespace",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Total energy consumption on the GPU that a certain container has used.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "left",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "watt"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 12,
-        "x": 12,
-        "y": 29
-      },
-      "id": 27,
-      "links": [
-        {
-          "targetBlank": true,
-          "title": "kepler_container_gpu_joules_total",
-          "url": "https://github.com/sustainable-computing-io/kepler-doc/blob/84e3e01a0110829937cd40f9634dd8d0c92540a4/docs/design/metrics.md#kepler-metrics-for-container-energy-consumption"
-        }
-      ],
-      "options": {
-        "legend": {
-          "calcs": ["lastNotNull"],
-          "displayMode": "table",
-          "placement": "right",
-          "sortBy": "Mean",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": "prometheus",
-          "editorMode": "code",
-          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[5m]))",
-          "hide": false,
-          "interval": "5m",
-          "legendFormat": "{{pod_name}} / {{container_namespace}} / GPU",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Pod/Process (GPU) Power Consumption (W) in Namespace: $namespace",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
       "description": "Power Consumption (W) of Top10 processes in Namespace or Top 10 Namespace if ALL namespaces is selected",
       "fieldConfig": {
         "defaults": {
@@ -877,7 +493,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 39
+        "y": 19
       },
       "id": 2,
       "options": {
@@ -945,7 +561,7 @@
           "refId": "D"
         }
       ],
-      "title": "Total Power Consumption (W) of Top10 processes in Namespace: $namespace",
+      "title": "Total Power Consumption (W) of processes in Namespace: $namespace",
       "type": "timeseries"
     },
     {
@@ -953,7 +569,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Total Power Consumption (kWh per day) of Top10 processes in Namespace or Top10 Namespace if All Namespaces selected",
+      "description": "Total Power Consumption (kWh per day) of processes in Namespace or Top10 Namespace if All Namespaces selected",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1067,7 +683,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 39
+        "y": 19
       },
       "id": 17,
       "options": {
@@ -1137,7 +753,391 @@
           "refId": "D"
         }
       ],
-      "title": "Total Power Consumption (kWh per day) of Top10 processes in Namespace: $namespace",
+      "title": "Total Power Consumption (kWh per day) of processes in Namespace: $namespace",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Cumulative energy consumed by the CPU socket, including all cores and uncore components (e.g. last-level cache, integrated GPU and memory controller).\n",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 16,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "kepler_container_package_joules_total",
+          "url": "https://github.com/sustainable-computing-io/kepler-doc/blob/84e3e01a0110829937cd40f9634dd8d0c92540a4/docs/design/metrics.md#kepler-metrics-for-container-energy-consumption"
+        }
+      ],
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "prometheus",
+          "editorMode": "code",
+          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_package_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[5m]))",
+          "hide": false,
+          "interval": "5m",
+          "legendFormat": "{{pod_name}} / {{container_namespace}} / PKG",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pod/Process (PKG) Power Consumption (W) in Namespace: $namespace",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "The total energy spent in DRAM by a container.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 23,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "kepler_container_dram_joules_total",
+          "url": "https://github.com/sustainable-computing-io/kepler-doc/blob/84e3e01a0110829937cd40f9634dd8d0c92540a4/docs/design/metrics.md#kepler-metrics-for-container-energy-consumption"
+        }
+      ],
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "prometheus",
+          "editorMode": "code",
+          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_dram_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[5m]))",
+          "hide": false,
+          "interval": "5m",
+          "legendFormat": "{{pod_name}} / {{container_namespace}} / DRAM",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Pod/Process (DRAM) Power Consumption (W) in Namespace: $namespace",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Cumulative energy consumption on other host components besides the CPU and DRAM",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 37
+      },
+      "id": 26,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "kepler_container_other_joules_total",
+          "url": "https://github.com/sustainable-computing-io/kepler-doc/blob/84e3e01a0110829937cd40f9634dd8d0c92540a4/docs/design/metrics.md#kepler-metrics-for-container-energy-consumption"
+        }
+      ],
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "prometheus",
+          "editorMode": "code",
+          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_other_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[5m]))",
+          "hide": false,
+          "interval": "5m",
+          "legendFormat": "{{pod_name}} / {{container_namespace}} / OTHER",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pod/Process (OTHER) Power Consumption (W) in Namespace: $namespace",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Total energy consumption on the GPU that a certain container has used.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 37
+      },
+      "id": 27,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "kepler_container_gpu_joules_total",
+          "url": "https://github.com/sustainable-computing-io/kepler-doc/blob/84e3e01a0110829937cd40f9634dd8d0c92540a4/docs/design/metrics.md#kepler-metrics-for-container-energy-consumption"
+        }
+      ],
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "prometheus",
+          "editorMode": "code",
+          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[5m]))",
+          "hide": false,
+          "interval": "5m",
+          "legendFormat": "{{pod_name}} / {{container_namespace}} / GPU",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pod/Process (GPU) Power Consumption (W) in Namespace: $namespace",
       "type": "timeseries"
     }
   ],

--- a/hack/dashboard/assets/kepler/dashboard.json
+++ b/hack/dashboard/assets/kepler/dashboard.json
@@ -57,8 +57,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 6,
+        "h": 6,
+        "w": 8,
         "x": 0,
         "y": 0
       },
@@ -144,17 +144,17 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 3,
-        "x": 6,
+        "h": 3,
+        "w": 6,
+        "x": 8,
         "y": 0
       },
       "id": 25,
       "links": [
         {
           "targetBlank": true,
-          "title": "kepler_node_platform_joules_total",
-          "url": "https://github.com/sustainable-computing-io/kepler-doc/blob/84e3e01a0110829937cd40f9634dd8d0c92540a4/docs/design/metrics.md#kepler-metrics-for-node-energy-consumption"
+          "title": "kepler_container_joules_total",
+          "url": "https://github.com/sustainable-computing-io/kepler-doc/blob/84e3e01a0110829937cd40f9634dd8d0c92540a4/docs/design/metrics.md#kepler-metrics-for-container-energy-consumption"
         }
       ],
       "options": {
@@ -177,8 +177,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (source) (\n    (\n      sum by (source) (\n        increase(kepler_node_platform_joules_total[1h])\n      ) * $watt_per_second_to_kWh\n    ) * (\n      sum by (source) (\n        count_over_time(kepler_node_platform_joules_total[24h])\n      ) / sum by (source) (\n        count_over_time(kepler_node_platform_joules_total[1h])\n      )\n    )\n  )",
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": " sum(sum by (container_namespace) (\n  (increase(kepler_container_joules_total{container_namespace=~\".*\"}[1h])\n    * $watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_joules_total{container_namespace=~\".*\"}[24h])/\n    count_over_time(kepler_container_joules_total{container_namespace=~\".*\"}[1h])\n  )\n))",
           "hide": false,
+          "instant": true,
+          "range": false,
           "refId": "A"
         }
       ],
@@ -218,9 +222,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 3,
-        "x": 9,
+        "h": 3,
+        "w": 6,
+        "x": 14,
         "y": 0
       },
       "id": 22,
@@ -261,7 +265,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 7
+        "y": 6
       },
       "id": 8,
       "panels": [],
@@ -297,13 +301,13 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 7
       },
       "id": 18,
       "links": [
         {
           "targetBlank": true,
-          "title": "kepler_container_packages_joules_total",
+          "title": "kepler_container_joules_total",
           "url": "https://github.com/sustainable-computing-io/kepler-doc/blob/84e3e01a0110829937cd40f9634dd8d0c92540a4/docs/design/metrics.md#kepler-metrics-for-container-energy-consumption"
         }
       ],
@@ -328,15 +332,17 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10,\n  sum by (container_namespace) (\n    (\n      sum by (container_namespace) (\n        increase(kepler_container_package_joules_total{container_namespace=~\".*\"}[1h])\n      ) * $watt_per_second_to_kWh\n    ) * (\n      sum by (container_namespace) (\n        count_over_time(kepler_container_package_joules_total{container_namespace=~\".*\"}[24h])\n      ) / sum by (container_namespace) (\n        count_over_time(kepler_container_package_joules_total{container_namespace=~\".*\"}[1h])\n      )\n    )\n    +\n    (\n      sum by (container_namespace) (\n        increase(kepler_container_dram_joules_total{container_namespace=~\".*\"}[1h])\n      ) * $watt_per_second_to_kWh\n    ) * (\n      sum by (container_namespace) (\n        count_over_time(kepler_container_dram_joules_total{container_namespace=~\".*\"}[24h])\n      ) / sum by (container_namespace) (\n        count_over_time(kepler_container_dram_joules_total{container_namespace=~\".*\"}[1h])\n      )\n    )\n  )\n)\n",
+          "exemplar": false,
+          "expr": "topk(10,\n  sum by (container_namespace) (\n  (increase(kepler_container_joules_total{container_namespace=~\".*\"}[1h])\n    * $watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_joules_total{container_namespace=~\".*\"}[24h])/\n    count_over_time(kepler_container_joules_total{container_namespace=~\".*\"}[1h])\n  )\n))\n",
           "format": "table",
+          "instant": true,
           "interval": "",
           "legendFormat": "{{container_namespace}}",
-          "range": true,
+          "range": false,
           "refId": "A"
         }
       ],
-      "title": "Total Power Consumption (PKG+DRAM) for Top 10 Namespaces",
+      "title": "Total Power Consumption for Top 10 Namespaces",
       "transformations": [
         {
           "id": "groupBy",
@@ -426,7 +432,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 20
+        "y": 19
       },
       "id": 16,
       "links": [
@@ -522,7 +528,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 20
+        "y": 19
       },
       "id": 23,
       "links": [
@@ -618,7 +624,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 30
+        "y": 29
       },
       "id": 26,
       "links": [
@@ -714,7 +720,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 30
+        "y": 29
       },
       "id": 27,
       "links": [
@@ -871,7 +877,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 40
+        "y": 39
       },
       "id": 2,
       "options": {
@@ -939,7 +945,7 @@
           "refId": "D"
         }
       ],
-      "title": "Power Consumption (W) of Top10 processes in Namespace: $namespace",
+      "title": "Total Power Consumption (W) of Top10 processes in Namespace: $namespace",
       "type": "timeseries"
     },
     {
@@ -1061,7 +1067,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 40
+        "y": 39
       },
       "id": 17,
       "options": {
@@ -1193,7 +1199,7 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "All",
           "value": "$__all"
         },


### PR DESCRIPTION
This PR updates the Grafana dashboard by:
* Adds panel that shows a list of CPU architecture and the corresponding count of nodes.
* Adds panel that shows the Total number of Kepler exporter pods. This will correspond to a number of nodes where the Kepler exporter daemon set is deployed.
* Adds a tooltip to each panel that links to [Kepler-doc's](https://github.com/sustainable-computing-io/kepler-doc/blob/84e3e01a0110829937cd40f9634dd8d0c92540a4/docs/design/metrics.md#kepler-metrics-for-node-information) that contains a brief description of each and every metric used.
* Adds panel that shows total energy consumption by source. (Using `kepler_node_platform_joules_total`)
* Separate out Pod/Process Power Consumption (W) in Namespace to different panels wrt PKG/DRAM/OTHER/GPU.
* Update existing panels(i.e. Total Power Consumption (PKG+DRAM) for Top 10 Namespaces, Power Consumption (W) of Top10 processes in Namespace: $namespace, Total Power Consumption (kWh per day) of Top10 processes in Namespace: $namespace)

Dashboard Screenshot:

![Screenshot 2023-09-11 at 11 32 22 PM](https://github.com/sustainable-computing-io/kepler-operator/assets/115542213/64ff0384-8a3d-4797-b939-80864e787a70)

![Screenshot 2023-09-11 at 11 32 33 PM](https://github.com/sustainable-computing-io/kepler-operator/assets/115542213/073c6048-09b5-42b0-b043-2ff031b99b8f)

