### PR TITLE
feat: support vanilla k8s cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,9 +142,12 @@ build: manifests generate fmt vet ## Build manager binary.
 	go build -o bin/manager cmd/manager/...
 
 .PHONY: run
-run: install fmt vet ## Run a controller from your host.
-	go run ./cmd/manager/... --zap-devel --zap-log-level=8 | tee tmp/operator.log
+run: install fmt vet ## Run a controller from your host against openshift cluster
+	go run ./cmd/manager/... --zap-devel --zap-log-level=8 --openshift | tee tmp/operator.log
 
+.PHONY: run-k8s
+run-k8s: install fmt vet ## Run a controller from your host against vanilla k8s cluster
+	go run ./cmd/manager/... --zap-devel --zap-log-level=8  | tee tmp/operator.log
 
 # docker_tag accepts an image:tag and a list of additional tags comma-separated
 # it tags the image with the additional tags

--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.7.3
-    createdAt: "2023-09-12T11:48:55Z"
+    createdAt: "2023-09-12T12:19:29Z"
     description: 'Deploys and Manages Kepler on Kubernetes '
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -216,6 +216,7 @@ spec:
                         - linux
               containers:
               - args:
+                - --openshift
                 - --leader-elect
                 - --zap-log-level=5
                 command:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,6 +69,8 @@ spec:
       - command:
         - /manager
         args:
+        # TODO: move --openshift to openshift specific kustomize directory
+        - --openshift
         - --leader-elect
         - --zap-log-level=5
         image: '<OPERATOR_IMG>'

--- a/pkg/utils/k8s/k8s.go
+++ b/pkg/utils/k8s/k8s.go
@@ -26,6 +26,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type Cluster int
+
+const (
+	Kubernetes Cluster = iota
+	OpenShift
+)
+
 type StringMap map[string]string
 
 type SCCAllows struct {


### PR DESCRIPTION
   This PR add a `--openshift` flag to operator which instructs operator
    to deploy components that are specific to openshift only if the flag is
    set. This allows the operator to be run against a vanilla k8s cluster by
    not setting this flag (which is the default).
