### PR TITLE
fix(bundle): installation of bundle on openshift

### DIFF
--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.7.3
-    createdAt: "2023-09-12T07:58:33Z"
+    createdAt: "2023-09-12T11:48:55Z"
     description: 'Deploys and Manages Kepler on Kubernetes '
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -48,12 +48,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:conditions
       version: v1alpha1
-    required:
-    - description: prometheus service monitor
-      displayName: ServiceMonitor
-      kind: ServiceMonitor
-      name: servicemonitors.monitoring.coreos.com
-      version: v1
   description: |
     ### Introduction
     Kepler (Kubernetes Efficient Power Level Exporter) uses eBPF to probe

--- a/config/manifests/bases/kepler-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kepler-operator.clusterserviceversion.yaml
@@ -26,12 +26,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:conditions
       version: v1alpha1
-    required:
-    - description: prometheus service monitor
-      displayName: ServiceMonitor
-      kind: ServiceMonitor
-      name: servicemonitors.monitoring.coreos.com
-      version: v1
   description: |
     ### Introduction
     Kepler (Kubernetes Efficient Power Level Exporter) uses eBPF to probe


### PR DESCRIPTION
This commit fixes the installation of bundle on openshift which fails because of the required CRD servicemonitor (which is provided by Prometheus Operator). Although the CRD is present in the cluster, OLM seems to be installing PO which conflicts with the in-cluster Prometheus Operator. The fix is to remove the dependency in CSV on ServiceMonitors