### PR TITLE
fix: print-columns after exporter spec refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,11 +143,11 @@ build: manifests generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: install fmt vet ## Run a controller from your host against openshift cluster
-	go run ./cmd/manager/... --zap-devel --zap-log-level=8 --openshift | tee tmp/operator.log
+	go run ./cmd/manager/... --zap-devel --zap-log-level=8 --openshift 2>&1 | tee tmp/operator.log
 
 .PHONY: run-k8s
 run-k8s: install fmt vet ## Run a controller from your host against vanilla k8s cluster
-	go run ./cmd/manager/... --zap-devel --zap-log-level=8  | tee tmp/operator.log
+	go run ./cmd/manager/... --zap-devel --zap-log-level=8  2>&1 | tee tmp/operator.log
 
 # docker_tag accepts an image:tag and a list of additional tags comma-separated
 # it tags the image with the additional tags

--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.7.3
-    createdAt: "2023-09-12T12:19:29Z"
+    createdAt: "2023-09-12T23:22:50Z"
     description: 'Deploys and Manages Kepler on Kubernetes '
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/kepler.system.sustainable.computing.io_keplers.yaml
+++ b/bundle/manifests/kepler.system.sustainable.computing.io_keplers.yaml
@@ -15,7 +15,7 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.exporter.port
+    - jsonPath: .spec.exporter.deployment.port
       name: Port
       type: integer
     - jsonPath: .status.desiredNumberScheduled
@@ -36,11 +36,11 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    - jsonPath: .spec.exporter.nodeSelector
+    - jsonPath: .spec.exporter.deployment.nodeSelector
       name: Node-Selector
       priority: 10
       type: string
-    - jsonPath: .spec.exporter.tolerations
+    - jsonPath: .spec.exporter.deployment.tolerations
       name: Tolerations
       priority: 10
       type: string

--- a/config/crd/bases/kepler.system.sustainable.computing.io_keplers.yaml
+++ b/config/crd/bases/kepler.system.sustainable.computing.io_keplers.yaml
@@ -15,7 +15,7 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.exporter.port
+    - jsonPath: .spec.exporter.deployment.port
       name: Port
       type: integer
     - jsonPath: .status.desiredNumberScheduled
@@ -36,11 +36,11 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    - jsonPath: .spec.exporter.nodeSelector
+    - jsonPath: .spec.exporter.deployment.nodeSelector
       name: Node-Selector
       priority: 10
       type: string
-    - jsonPath: .spec.exporter.tolerations
+    - jsonPath: .spec.exporter.deployment.tolerations
       name: Tolerations
       priority: 10
       type: string

--- a/pkg/api/v1alpha1/kepler_types.go
+++ b/pkg/api/v1alpha1/kepler_types.go
@@ -234,15 +234,15 @@ type KeplerStatus struct {
 //+kubebuilder:resource:scope="Cluster"
 //+kubebuilder:subresource:status
 
-// +kubebuilder:printcolumn:name="Port",type=integer,JSONPath=`.spec.exporter.port`
+// +kubebuilder:printcolumn:name="Port",type=integer,JSONPath=`.spec.exporter.deployment.port`
 // +kubebuilder:printcolumn:name="Desired",type=integer,JSONPath=`.status.desiredNumberScheduled`
 // +kubebuilder:printcolumn:name="Current",type=integer,JSONPath=`.status.currentNumberScheduled`
 // +kubebuilder:printcolumn:name="Ready",type=integer,JSONPath=`.status.numberReady`
 // +kubebuilder:printcolumn:name="Up-to-date",type=integer,JSONPath=`.status.updatedNumberScheduled`
 // +kubebuilder:printcolumn:name="Available",type=integer,JSONPath=`.status.numberAvailable`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:printcolumn:name="Node-Selector",type=string,JSONPath=`.spec.exporter.nodeSelector`,priority=10
-// +kubebuilder:printcolumn:name="Tolerations",type=string,JSONPath=`.spec.exporter.tolerations`,priority=10
+// +kubebuilder:printcolumn:name="Node-Selector",type=string,JSONPath=`.spec.exporter.deployment.nodeSelector`,priority=10
+// +kubebuilder:printcolumn:name="Tolerations",type=string,JSONPath=`.spec.exporter.deployment.tolerations`,priority=10
 //
 // Kepler is the Schema for the keplers API
 type Kepler struct {


### PR DESCRIPTION
`kubectl get kepler` did not print the exporter port and the nodeSelectors after
the refactor for deployment settings to `deployment` field. This fixes the `printcolumns`
to point to the right path. 
 