### PR TITLE
fix: restore SCC to allow privileged containers on OpenShift

### DIFF
--- a/docs/developer/test-plan.md
+++ b/docs/developer/test-plan.md
@@ -38,6 +38,12 @@
   - `packagemanifests`
   - `catalog`
 
+- The Operator should not enter into an infinite reconcile loop. This can be
+  verified by:
+	- checking the logs of the Operator.
+	- checking if the `metadata.resourceVersion` keeps increasing / changing in a
+	  short interval say every 2-5 seconds.
+
 #### Negative:
 
 - OpenShift console should log appropriate errors in case of unsuccessful installation of Operator.

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -56,7 +56,9 @@ func NewKeplerNamespace() *corev1.Namespace {
 				//   privileged (container "kepler-exporter" must not set securityContext.privileged=true),
 				//   allowPrivilegeEscalation != false (container "kepler-exporter" must set
 				//   securityContext.allowPrivilegeEscalation=false),
+				"pod-security.kubernetes.io/audit":   "privileged",
 				"pod-security.kubernetes.io/enforce": "privileged",
+				"pod-security.kubernetes.io/warn":    "privileged",
 			}),
 			//TODO: ensure in-cluster monitoring ignores this ns
 		},

--- a/pkg/components/exporter/exporter.go
+++ b/pkg/components/exporter/exporter.go
@@ -331,13 +331,12 @@ func NewSCC(d components.Detail, k *v1alpha1.Kepler) *secv1.SecurityContextConst
 			Name:   SCCName,
 			Labels: labels,
 		},
-
-		AllowPrivilegedContainer: true,
 		AllowHostDirVolumePlugin: true,
-		AllowHostIPC:             false,
-		AllowHostNetwork:         false,
+		AllowPrivilegedContainer: true,
+		AllowHostNetwork:         true,
 		AllowHostPID:             true,
-		AllowHostPorts:           false,
+		AllowHostIPC:             true,
+		AllowHostPorts:           true,
 		DefaultAddCapabilities:   []corev1.Capability{corev1.Capability("SYS_ADMIN")},
 
 		FSGroup: secv1.FSGroupStrategyOptions{
@@ -350,13 +349,8 @@ func NewSCC(d components.Detail, k *v1alpha1.Kepler) *secv1.SecurityContextConst
 		SELinuxContext: secv1.SELinuxContextStrategyOptions{
 			Type: secv1.SELinuxStrategyRunAsAny,
 		},
-		//TODO: decide if "kepler" is really needed?
-		Users: []string{"kepler", FQServiceAccountName},
-		Volumes: []secv1.FSType{
-			secv1.FSType("configMap"),
-			secv1.FSType("projected"),
-			secv1.FSType("emptyDir"),
-			secv1.FSType("hostPath")},
+		Users:   []string{FQServiceAccountName},
+		Volumes: []secv1.FSType{secv1.FSTypeAll},
 	}
 }
 

--- a/pkg/components/exporter/exporter_test.go
+++ b/pkg/components/exporter/exporter_test.go
@@ -196,10 +196,10 @@ func TestSCCAllows(t *testing.T) {
 			sccAllows: k8s.SCCAllows{
 				AllowPrivilegedContainer: true,
 				AllowHostDirVolumePlugin: true,
-				AllowHostIPC:             false,
-				AllowHostNetwork:         false,
+				AllowHostIPC:             true,
+				AllowHostNetwork:         true,
 				AllowHostPID:             true,
-				AllowHostPorts:           false,
+				AllowHostPorts:           true,
 			},
 			scenario: "default case",
 		},

--- a/pkg/controllers/kepler.go
+++ b/pkg/controllers/kepler.go
@@ -408,7 +408,13 @@ func exporterReconcilers(k *v1alpha1.Kepler, cluster k8s.Cluster) []reconciler.R
 		return rs
 	}
 
-	rs := updatersForResources(k,
+	rs := []reconciler.Reconciler{}
+	if cluster == k8s.OpenShift {
+		updater := newUpdaterForKepler(k)
+		rs = append(rs, updater(exporter.NewSCC(components.Full, k)))
+	}
+
+	rs = append(rs, updatersForResources(k,
 		// cluster-scoped resources first
 		exporter.NewClusterRole(components.Full),
 		exporter.NewClusterRoleBinding(components.Full),
@@ -419,12 +425,8 @@ func exporterReconcilers(k *v1alpha1.Kepler, cluster k8s.Cluster) []reconciler.R
 		exporter.NewDaemonSet(components.Full, k),
 		exporter.NewService(k),
 		exporter.NewServiceMonitor(),
-	)
+	)...)
 
-	if cluster == k8s.OpenShift {
-		updater := newUpdaterForKepler(k)
-		rs = append(rs, updater(exporter.NewSCC(components.Full, k)))
-	}
 	return rs
 }
 


### PR DESCRIPTION
A good reference for the SCC required is the node-exporter SCC from CMO that deploys run node-exporter daemonset. 
see:   https://github.com/openshift/cluster-monitoring-operator/blob/master/assets/node-exporter/security-context-constraints.yaml 

Without this patch, although the pods are deployed, the reconciler keeps running in infinite loop. 

