### PR TITLE
chore: update release workflow to include version replaces in bundle

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,12 +4,12 @@ on:
     # Inputs the workflow accepts.
     inputs:
       tag:
-        description: "Tag name, e.g. 0.4.0"
-        default: 0.6.0
+        description: "Tag name, e.g. 0.8.0"
+        default: ""
         required: true
-      release:
-        description: "Release name, e.g. release-0.4.0"
-        default: release-0.6.0
+      version-replace:
+        description: "Version to be replaced in bundle, e.g. 0.7.3"
+        default: ""
         required: true
 
 jobs:
@@ -41,7 +41,6 @@ jobs:
         env:
           USERNAME: ${{ github.actor }}
 
-
       - name: Update the VERSION
         run: |
           echo "$VERSION" > VERSION
@@ -59,6 +58,7 @@ jobs:
           make bundle bundle-build
         env:
           IMG_BASE: ${{ vars.IMG_BASE }}
+          VERSION_REPLACED: ${{ github.event.inputs.version-replace }}
 
       - name: Commit bundle changes and tag it
         run: |
@@ -86,10 +86,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: "v${{ github.event.inputs.tag }}"
-          release_name: ${{ github.event.inputs.release }}
+          release_name: "release-${{github.event.inputs.tag}}"
           draft: false
           prerelease: false
-
 
   create-release-branch:
     name: Create release branch
@@ -98,10 +97,10 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-    - name: Create release branch
-      uses: peterjgrainger/action-create-branch@v2.2.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        branch: ${{ github.event.inputs.release }}
-        sha: '${{ github.event.pull_request.head.sha }}'
+      - name: Create release branch
+        uses: peterjgrainger/action-create-branch@v2.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          branch: "release-${{github.event.inputs.tag}}"
+          sha: "${{ github.event.pull_request.head.sha }}"


### PR DESCRIPTION
This PR updates the release workflow to include `VERSION_REPLACED` while building the bundle. This will be useful when publishing the bundle to the community catalog.

Test workflow [run](https://github.com/vprashar2929/kepler-operator/actions/runs/6175536737/job/16762617447#step:7:54)