### PR TITLE
feat: package go test to run in prow CI

### DIFF
--- a/.github/publish-images/action.yaml
+++ b/.github/publish-images/action.yaml
@@ -1,5 +1,5 @@
 name: Build and Publish Images
-description: 'Publishes operator and bundle images to an Image Registry'
+description: "Publishes operator and bundle images to an Image Registry"
 inputs:
   image_registry:
     description: "image registry"
@@ -30,14 +30,13 @@ runs:
         check-latest: true
         cache: true
 
-    - name: Login to Image Registry 
+    - name: Login to Image Registry
       uses: docker/login-action@v2
       if: "!startsWith(inputs.image_registry, 'localhost')"
       with:
         registry: ${{ inputs.image_registry }}
         username: ${{ inputs.registry_login }}
         password: ${{ inputs.registry_token }}
-      
 
     - name: Build Operator
       shell: bash
@@ -56,6 +55,14 @@ runs:
         VERSION: ${{ inputs.version }}
         IMG_BASE: ${{ inputs.image_registry }}
         ADDITIONAL_TAGS: ${{ inputs.additional_tags }}
+
+    - name: Build E2E
+      shell: bash
+      run: |
+        make e2e-test-image
+      env:
+        VERSION: ${{ inputs.version }}
+        IMG_BASE: ${{ inputs.image_registry }}
 
     - name: Push Images
       shell: bash

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ ADDITIONAL_TAGS ?=
 
 KEPLER_IMG ?= $(IMG_BASE)/kepler:$(KEPLER_VERSION)
 
+# E2E_TEST_IMG defines the image:tag used for the e2e test image
+E2E_TEST_IMG ?=$(IMG_BASE)/kepler-operator-e2e:$(VERSION)
 
 .PHONY: fresh
 fresh: ## default target - sets up a k8s cluster with images ready for deployment
@@ -207,6 +209,12 @@ operator-build: manifests generate test ## Build docker image with the manager.
 operator-push: ## Push docker image with the manager.
 	$(call docker_push,$(OPERATOR_IMG),$(ADDITIONAL_TAGS))
 
+
+.PHONY: e2e-test-image
+e2e-test-image: test
+	docker build -f tests/Dockerfile \
+		--platform=linux/$(GOARCH) \
+		-t $(E2E_TEST_IMG) .
 
 ##@ Deployment
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,23 @@
+# The Dockerfile's resulting image is used in executing Kepler Operator e2e tests on ProwCI
+FROM golang:1.20
+
+WORKDIR /workspace
+
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# Cache dependencies before building source
+RUN go mod download
+
+# Install kubectl and oc
+RUN curl -L -o oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux.tar.gz \
+    && tar -xvzf oc.tar.gz \
+    && chmod +x kubectl oc \
+    && mv oc kubectl /usr/local/bin/
+
+# Copy the go source
+COPY pkg/ pkg/
+COPY tests/ tests/
+
+# Compile test into e2e.test binary
+RUN go test -c ./tests/e2e/


### PR DESCRIPTION
This PR creates a Dockerfile under the `tests` dir which will build a test binary that downstream prow CI will consume in running e2e tests on OpenShift.