### PR TITLE
feat(bundle): Use user supplied kepler image

### DIFF
--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.8.0
-    createdAt: "2023-09-13T07:31:42Z"
+    createdAt: "2023-09-20T10:50:40Z"
     description: 'Deploys and Manages Kepler on Kubernetes '
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -218,9 +218,13 @@ spec:
               - args:
                 - --openshift
                 - --leader-elect
+                - --kepler.image=$(RELATED_IMAGE_KEPLER)
                 - --zap-log-level=5
                 command:
                 - /manager
+                env:
+                - name: RELATED_IMAGE_KEPLER
+                  value: quay.io/sustainable_computing_io/kepler:release-0.5.5
                 image: quay.io/sustainable_computing_io/kepler-operator:0.8.0
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
@@ -322,5 +326,8 @@ spec:
   provider:
     name: Kepler Operator Contributors
     url: https://sustainable-computing.io/
+  relatedImages:
+  - image: quay.io/sustainable_computing_io/kepler:release-0.5.5
+    name: kepler
   replaces: kepler-operator.v0.7.3
   version: 0.8.0

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -59,14 +59,6 @@ func init() {
 	//+kubebuilder:scaffold:scheme
 }
 
-func env(name, defaultValue string) string {
-	value := os.Getenv(name)
-	if len(value) == 0 {
-		return defaultValue
-	}
-	return value
-}
-
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
@@ -82,8 +74,8 @@ func main() {
 	flag.BoolVar(&openshift, "openshift", false,
 		"Indicate if the operator is running on an OpenShift cluster.")
 
-	// NOTE: KEPLER_IMAGE can be set as env or flag, flag takes precedence over env
-	keplerImage := env("KEPLER_IMAGE", exporter.StableImage)
+	// NOTE: RELATED_IMAGE_KEPLER can be set as env or flag, flag takes precedence over env
+	keplerImage := os.Getenv("RELATED_IMAGE_KEPLER")
 	flag.StringVar(&exporter.Config.Image, "kepler.image", keplerImage, "kepler image")
 
 	opts := zap.Options{

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -68,10 +68,14 @@ spec:
       containers:
       - command:
         - /manager
+        env:
+          - name: RELATED_IMAGE_KEPLER
+            value: '<KEPLER_IMG>'
         args:
         # TODO: move --openshift to openshift specific kustomize directory
         - --openshift
         - --leader-elect
+        - --kepler.image=$(RELATED_IMAGE_KEPLER)
         - --zap-log-level=5
         image: '<OPERATOR_IMG>'
         imagePullPolicy: IfNotPresent

--- a/hack/bundle.sh
+++ b/hack/bundle.sh
@@ -65,6 +65,7 @@ main() {
 	kustomize build config/manifests |
 		sed \
 			-e "s|<OPERATOR_IMG>|$OPERATOR_IMG|g" \
+			-e "s|<KEPLER_IMG>|$KEPLER_IMG|g" \
 			-e "s|<OLD_BUNDLE_VERSION>|$old_bundle_version|g" |
 		tee tmp/pre-bundle.yaml |
 		operator-sdk generate bundle "${gen_opts[@]}"

--- a/pkg/components/exporter/exporter.go
+++ b/pkg/components/exporter/exporter.go
@@ -51,17 +51,13 @@ const (
 	ServiceName        = prefix + "svc"
 	ServicePortName    = "http"
 	ServiceMonitorName = prefix + "smon"
-
-	StableImage = "quay.io/sustainable_computing_io/kepler:release-0.5.5"
 )
 
 // Config that will be set from outside
 var (
 	Config = struct {
 		Image string
-	}{
-		Image: StableImage,
-	}
+	}{}
 )
 
 var (

--- a/tests/run-e2e.sh
+++ b/tests/run-e2e.sh
@@ -8,6 +8,7 @@ declare -r PROJECT_ROOT
 
 source "$PROJECT_ROOT/hack/utils.bash"
 
+declare -r LOCAL_BIN="$PROJECT_ROOT/tmp/bin"
 declare -r OPERATOR="kepler-operator"
 declare -r OLM_CATALOG="kepler-operator-catalog"
 declare -r VERSION="0.0.0-e2e"
@@ -260,7 +261,7 @@ kind_load_images() {
 	while read -r img; do
 		run docker pull "$img"
 		run kind load docker-image "$img"
-	done < <(grep -e '=\s\+"quay.io' -r pkg/components/exporter | cut -f2 -d'"')
+  done < <(yq -r .spec.relatedImages[].image bundle/manifests//kepler-operator.clusterserviceversion.yaml)
 }
 
 deploy_operator() {
@@ -346,6 +347,7 @@ print_config() {
 }
 
 main() {
+	export PATH="$LOCAL_BIN:$PATH"
 	parse_args "$@" || die "parse args failed"
 	$SHOW_USAGE && {
 		print_usage


### PR DESCRIPTION
For dev testing sometimes it is needed to change the kepler image to be deployed. This PR lets devs use an env variable to specify the kepler image.

 - Makefile: variable(s) for defining kepler image, which form the 'official' image used in the bundle, but whose value can be overridden by user while building bundle
 - CSV: added env variable `RELATED_IMAGE_KEPLER` in kepler operator deployment which gets passed as an argument to manager, and its value can be overridden by user while building the bundle by supplying env variables `KEPLER_IMG` or `KEPLER_VERSION`
 - exporter/main/go: changed to use the new env variable `RELATED_IMAGE_KEPLER`
 - hack/bundle.sh: replace `KEPLER_IMG` with its value in CSV
 - operator-sdk adds `relatedImages` field based on `RELATED_IMAGE*` variables used

**Example Usage 1**: use your own built kepler image from `quay.io/<your-repo>`
make bundle as usual, but with extra env variable for KEPLER_VERSION. this will use kepler image from `quay.io/<your-repo>`. Then run the bundle, and create kepler instance
```
make bundle bundle-build bundle-push IMG_BASE=quay.io/vimalkum VERSION=0.0.0-test-1  KEPLER_VERSION=latest-libbpf

operator-sdk run bundle quay.io/vimalkum/kepler-operator-bundle:0.0.0-test-1  --install-mode AllNamespaces --namespace=operators

oc apply -f ./config/samples/kepler.system_v1alpha1_kepler.yaml
```

This will run kepler with image `quay.io/vimalkum/kepler:latest-libbpf`

**Example Usage 2:** use kepler image from another repo, e.g. `quay.io/sustainability_computing_io`
make bundle as usual, but with extra env variable for KEPLER_IMG. this will use kepler image as per variable. Then run the bundle, and create kepler instance
```
make bundle bundle-build bundle-push IMG_BASE=quay.io/vimalkum VERSION=0.0.0-test-1  KEPLER_IMG=quay.io/sustainable_computing_io/kepler:latest-libbpf

operator-sdk run bundle quay.io/vimalkum/kepler-operator-bundle:0.0.0-test-1  --install-mode AllNamespaces --namespace=operators

oc apply -f ./config/samples/kepler.system_v1alpha1_kepler.yaml
```

This will run kepler with image `quay.io/sustainable_computing_io/kepler:latest-libbpf`