### PR TITLE
feat(must-gather): Added must-gather scripts

### DIFF
--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -1,0 +1,18 @@
+
+power monitoring must-gather
+============================
+
+power monitoring `must-gather` is a tool built on top of [Openshift must-gather](https://github.com/openshift/must-gather) that lets users to gather information about power monitoring components.
+
+### Usage
+```sh
+oc adm must-gather --image=$(oc -n openshift-operators get deployment.apps/kepler-operator-controller-manager -o jsonpath='{.spec.template.spec.containers[?(@.name == "manager")].image}') -- /usr/bin/gather
+```
+or
+```sh
+oc adm must-gather --image=quay.io/sustainable_computing_io/kepler-operator:v1alpha1
+```
+
+The above command will gather information about power monitoring and dump that information in a new directory.
+
+

--- a/must-gather/common
+++ b/must-gather/common
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# copyright 2023.
+#
+# licensed under the apache license, version 2.0 (the "license");
+# you may not use this file except in compliance with the license.
+# you may obtain a copy of the license at
+#
+#     http://www.apache.org/licenses/license-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the license is distributed on an "as is" basis,
+# without warranties or conditions of any kind, either express or implied.
+# see the license for the specific language governing permissions and
+# limitations under the license.
+#
+
+set -eu -o pipefail
+
+export KEPLER_NS="openshift-kepler-operator"
+export LOGFILE_NAME="gather-debug.log"
+
+get_timestamp(){
+  date -u +"%Y-%m-%d %H:%M:%SZ"
+}
+
+log_stdout() {
+  echo "$(get_timestamp) $*"
+}
+
+log_file() {
+  echo "$(get_timestamp) $*" >> "$LOGFILE_PATH"
+}
+
+log_stdout_and_file() {
+  echo "$(get_timestamp) $*" | tee -a "$LOGFILE_PATH"
+}
+
+log(){
+  log_stdout_and_file "$@"
+}
+
+run() {
+  length=$(($#-1))
+  cmd=${@:1:$length}
+  gather_file="${@: -1}"
+
+  log_file "$cmd"
+  $cmd >> "$gather_file"  2>> "$LOGFILE_PATH" || true
+}

--- a/must-gather/gather
+++ b/must-gather/gather
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+# copyright 2023.
+#
+# licensed under the apache license, version 2.0 (the "license");
+# you may not use this file except in compliance with the license.
+# you may obtain a copy of the license at
+#
+#     http://www.apache.org/licenses/license-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the license is distributed on an "as is" basis,
+# without warranties or conditions of any kind, either express or implied.
+# see the license for the specific language governing permissions and
+# limitations under the license.
+#
+
+set -eu -o pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+source "${SCRIPT_DIR}"/common
+
+print_usage() {
+    echo -e "Usage: /usr/bin/gather <gather-collection-path>"
+}
+
+get_kepler_instance() {
+  log "getting kepler instance(s)"
+  KEPLERS=$(oc get keplers.kepler.system.sustainable.computing.io -oname)
+  if [ ! -z "$KEPLERS" ]
+  then
+    run oc get $KEPLERS -oyaml "$BASE_COLLECTION_PATH/keplers.yaml"
+  else
+    echo "no keplers found" >> "$BASE_COLLECTION_PATH/keplers.yaml"
+  fi
+}
+
+get_kepler_events() {
+  log "getting $KEPLER_NS events"
+  run oc -n "$KEPLER_NS" get events "$BASE_COLLECTION_PATH/$KEPLER_NS""_events"
+}
+
+get_kepler_daemon_set() {
+  KEPLER_EXPORTER_DS="kepler-exporter-ds"
+  log "getting kepler exporter daemonset"
+  run oc -n "$KEPLER_NS" get ds $KEPLER_EXPORTER_DS -oyaml "$BASE_COLLECTION_PATH/$KEPLER_EXPORTER_DS"".yaml"
+}
+
+get_kepler_config_map() {
+  KEPLER_EXPORTER_CM="kepler-exporter-cm"
+  log "getting kepler exporter config map"
+  run oc -n "$KEPLER_NS" get cm $KEPLER_EXPORTER_CM -oyaml "$BASE_COLLECTION_PATH/$KEPLER_EXPORTER_CM"".yaml"
+}
+
+get_kepler_sa() {
+  KEPLER_EXPORTER_SA="kepler-exporter-sa"
+  log "getting kepler exporter service account"
+  run oc -n "$KEPLER_NS" get serviceaccount $KEPLER_EXPORTER_SA -oyaml "$BASE_COLLECTION_PATH/$KEPLER_EXPORTER_SA"".yaml"
+}
+
+get_kepler_scc() {
+  KEPLER_EXPORTER_SCC="kepler-exporter-scc"
+  log "getting kepler exporter scc"
+  run oc get scc "$KEPLER_EXPORTER_SCC" -oyaml "$BASE_COLLECTION_PATH/$KEPLER_EXPORTER_SCC"".yaml"
+}
+
+gather_kepler_exporter_info() {
+  KEPLER_PODS=$(oc -n "$KEPLER_NS" get pods -oname 2>/dev/null || echo "")
+  for pod in $KEPLER_PODS
+  do
+	pod=$(echo "$pod" | awk -F '/' '{print $2}')
+	log "running gather script for kepler pod: $pod"
+	"$SCRIPT_DIR"/gather-kepler-exporter-info "$BASE_COLLECTION_PATH" "$pod"
+  done
+}
+
+gather_olm_info(){
+  log "running gather script for olm"
+  "$SCRIPT_DIR"/gather-olm-info "$BASE_COLLECTION_PATH"
+}
+
+gather_kepler_operator_info() {
+  log "getting kepler-operator info"
+  "$SCRIPT_DIR"/gather-kepler-operator-info "$BASE_COLLECTION_PATH"
+}
+
+main(){
+  case ${1-} in
+	--help | -h )
+	  print_usage
+	  exit 0
+  esac
+
+  BASE_COLLECTION_PATH="${1:-/must-gather}"
+  export LOGFILE_PATH="${BASE_COLLECTION_PATH}/${LOGFILE_NAME}"
+
+  mkdir -p "${BASE_COLLECTION_PATH}"
+  cd "${BASE_COLLECTION_PATH}"
+  echo -e "must-gather logs are located at: '${LOGFILE_PATH}'"
+
+  mkdir -p "/tmp/cache-dir"
+  export KUBECACHEDIR=/tmp/cache-dir
+
+  echo "powermon must-gather started..."
+  get_kepler_instance
+  get_kepler_events
+  get_kepler_daemon_set
+  get_kepler_config_map
+  get_kepler_sa
+  get_kepler_scc
+  gather_kepler_exporter_info
+  gather_olm_info
+  gather_kepler_operator_info
+
+  echo "powermon must-gather completed"
+}
+
+main "$@"

--- a/must-gather/gather-kepler-exporter-info
+++ b/must-gather/gather-kepler-exporter-info
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# copyright 2023.
+#
+# licensed under the apache license, version 2.0 (the "license");
+# you may not use this file except in compliance with the license.
+# you may obtain a copy of the license at
+#
+#     http://www.apache.org/licenses/license-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the license is distributed on an "as is" basis,
+# without warranties or conditions of any kind, either express or implied.
+# see the license for the specific language governing permissions and
+# limitations under the license.
+#
+
+set -eu -o pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${SCRIPT_DIR}/common"
+
+BASE_COLLECTION_PATH=$1
+KEPLER_POD=$2
+
+get_kepler_pod(){
+  log "getting pod yaml for kepler pod: $KEPLER_POD"
+  run oc -n  "$KEPLER_NS" get pod "$KEPLER_POD" -oyaml "$KEPLER_POD_INFO_DIR/kepler-pod.yaml"
+}
+
+get_kepler_cpuid(){
+  log "getting information from \"cpuid\" from kepler pod: $KEPLER_POD"
+  run oc -n "$KEPLER_NS" exec "$KEPLER_POD" -c kepler-exporter -- cpuid -1 "$KEPLER_POD_INFO_DIR/node-cpuid-info"
+}
+
+get_kepler_env_var() {
+  log "getting environment variables from kepler pod: $KEPLER_POD"
+  run oc -n "$KEPLER_NS" exec "$KEPLER_POD" -c kepler-exporter -- env "$KEPLER_POD_INFO_DIR/env-variables"
+}
+
+get_kepler_kernel_info() {
+  log "getting kernel version from kepler pod: $KEPLER_POD"
+  echo "kernel version:" >> "$KEPLER_POD_INFO_DIR/kernel-info"
+  run oc -n "$KEPLER_NS" exec "$KEPLER_POD" -c kepler-exporter -- uname -a "$KEPLER_POD_INFO_DIR/kernel-info"
+}
+
+get_kepler_ebpf_info(){
+  log "getting ebpf information from kepler pod: $KEPLER_POD"
+  echo "## kprobes list only applicable for bcc" >> "$KEPLER_POD_INFO_DIR/ebpf-info"
+  echo "kprobes list:" >> "$KEPLER_POD_INFO_DIR/ebpf-info"
+  run oc -n "$KEPLER_NS" exec "$KEPLER_POD" -c kepler-exporter -- cat /sys/kernel/debug/kprobes/list "$KEPLER_POD_INFO_DIR/ebpf-info"
+}
+
+get_kepler_logs() {
+  log "getting logs from kepler pod: $KEPLER_POD"
+  run oc -n "$KEPLER_NS" logs "$KEPLER_POD" -c kepler-exporter "$KEPLER_POD_INFO_DIR/kepler.log"
+}
+
+main() {
+
+  KEPLER_POD_INFO_DIR="$BASE_COLLECTION_PATH/kepler-exporter-info/$KEPLER_POD"
+  mkdir -p "$KEPLER_POD_INFO_DIR"
+
+  get_kepler_pod
+  get_kepler_cpuid
+  get_kepler_env_var
+  get_kepler_kernel_info
+  get_kepler_ebpf_info
+  get_kepler_logs
+}
+
+main "$@"

--- a/must-gather/gather-kepler-operator-info
+++ b/must-gather/gather-kepler-operator-info
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# copyright 2023.
+#
+# licensed under the apache license, version 2.0 (the "license");
+# you may not use this file except in compliance with the license.
+# you may obtain a copy of the license at
+#
+#     http://www.apache.org/licenses/license-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the license is distributed on an "as is" basis,
+# without warranties or conditions of any kind, either express or implied.
+# see the license for the specific language governing permissions and
+# limitations under the license.
+#
+
+set -eu -o pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${SCRIPT_DIR}/common"
+
+BASE_COLLECTION_PATH=$1
+
+KEPLER_OPERATOR_NS="openshift-operators"
+
+get_catalogsource() {
+  log "getting catalogsource info for kepler-operator"
+  run oc -n "$KEPLER_OPERATOR_NS" get catalogsource kepler-operator-catalog -oyaml "$KEPLER_OPERATOR_INFO_DIR/kepler-operator-catalogsource.yaml"
+}
+
+get_subscription() {
+  log "getting subscription info for kepler-operator"
+  run oc -n "$KEPLER_OPERATOR_NS" get subscription -l operators.coreos.com/kepler-operator.openshift-operators= -oyaml "$KEPLER_OPERATOR_INFO_DIR/kepler-operator-subscription.yaml"
+}
+
+get_install_plan() {
+  log "getting installplan info for kepler-operator"
+  run oc -n "$KEPLER_OPERATOR_NS" get installplan -l operators.coreos.com/kepler-operator.openshift-operators= -oyaml "$KEPLER_OPERATOR_INFO_DIR/kepler-operator-installplan.yaml"
+}
+
+get_csv() {
+  log "getting CSV for kepler-operator"
+  run oc -n "$KEPLER_OPERATOR_NS" get csv -l operators.coreos.com/kepler-operator.openshift-operators= -oyaml "$KEPLER_OPERATOR_INFO_DIR/kepler-operator-csv.yaml"
+}
+
+get_kepler_operator_deployment_info() {
+  KEPLER_OPERATOR_DEPLOY="kepler-operator-controller-manager"
+  log "getting deployment info for kepler-operator"
+  run oc -n "$KEPLER_OPERATOR_NS" get deployment "$KEPLER_OPERATOR_DEPLOY" -oyaml "$KEPLER_OPERATOR_INFO_DIR/kepler-operator-deployment.yaml"
+}
+
+get_kepler_operator_pod_info() {
+  log "getting pod info for kepler-operator"
+  run oc -n "$KEPLER_OPERATOR_NS" get pod -l control-plane=controller-manager -oyaml "$KEPLER_OPERATOR_INFO_DIR/kepler-operator.yaml"
+}
+
+get_summary() {
+  run oc -n "$KEPLER_OPERATOR_NS" get catalogsource kepler-operator-catalog -owide "$KEPLER_OPERATOR_INFO_DIR/summary.txt"
+  echo -e "\n" >> "$KEPLER_OPERATOR_INFO_DIR/summary.txt"
+
+  run oc -n "$KEPLER_OPERATOR_NS" get subscription -owide "$KEPLER_OPERATOR_INFO_DIR/summary.txt"
+  echo -e "\n" >> "$KEPLER_OPERATOR_INFO_DIR/summary.txt"
+
+  run oc -n "$KEPLER_OPERATOR_NS" get installplan -owide "$KEPLER_OPERATOR_INFO_DIR/summary.txt"
+  echo -e "\n" >> "$KEPLER_OPERATOR_INFO_DIR/summary.txt"
+
+  run oc -n "$KEPLER_OPERATOR_NS" get csv -owide  "$KEPLER_OPERATOR_INFO_DIR/summary.txt"
+  echo -e "\n" >> "$KEPLER_OPERATOR_INFO_DIR/summary.txt"
+
+  KEPLER_OPERATOR_DEPLOY="kepler-operator-controller-manager"
+  run oc -n "$KEPLER_OPERATOR_NS" get deployment "$KEPLER_OPERATOR_DEPLOY" -owide "$KEPLER_OPERATOR_INFO_DIR/summary.txt"
+  echo -e "\n" >> "$KEPLER_OPERATOR_INFO_DIR/summary.txt"
+
+  run oc -n "$KEPLER_OPERATOR_NS" get pod -l control-plane=controller-manager -owide "$KEPLER_OPERATOR_INFO_DIR/summary.txt"
+}
+
+main() {
+
+  KEPLER_OPERATOR_INFO_DIR="$BASE_COLLECTION_PATH/kepler-operator-info"
+  mkdir -p "$KEPLER_OPERATOR_INFO_DIR"
+
+  get_subscription
+  get_catalogsource
+  get_install_plan
+  get_csv
+  get_kepler_operator_deployment_info
+  get_kepler_operator_pod_info
+  get_summary
+}
+
+main "$@"

--- a/must-gather/gather-olm-info
+++ b/must-gather/gather-olm-info
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# copyright 2023.
+#
+# licensed under the apache license, version 2.0 (the "license");
+# you may not use this file except in compliance with the license.
+# you may obtain a copy of the license at
+#
+#     http://www.apache.org/licenses/license-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the license is distributed on an "as is" basis,
+# without warranties or conditions of any kind, either express or implied.
+# see the license for the specific language governing permissions and
+# limitations under the license.
+#
+
+set -eu -o pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${SCRIPT_DIR}/common"
+
+BASE_COLLECTION_PATH=$1
+
+KEPLER_OPERATOR_NS="openshift-operators"
+KEPLER_OPERATOR_LABELS="operators.coreos.com/kepler-operator.openshift-operators"
+
+get_olm() {
+  log "collecting olm info for kepler-operator"
+  run oc -n "$KEPLER_OPERATOR_NS" get olm -l "${KEPLER_OPERATOR_LABELS}"= -oyaml "$OLM_INFO_DIR/olm-reources.yaml"
+}
+
+get_summary() {
+  log "collecting olm summary"
+  run oc -n "$KEPLER_OPERATOR_NS" get olm -owide "$OLM_INFO_DIR/summary.txt"
+}
+
+
+main() {
+
+  OLM_INFO_DIR=$BASE_COLLECTION_PATH/olm-info
+  mkdir -p "$OLM_INFO_DIR"
+
+  get_olm
+  get_summary
+}
+
+main "$@"


### PR DESCRIPTION
Thie PR adds `must-gather` scripts for kepler-operator

Sample execution on single node CRC cluster:
```
$ oc adm must-gather --image=$(oc -n openshift-operators get deployment.apps/kepler-operator-controller-manager -o jsonpath='{.spec.template.spec.containers[?(@.name == "manager")].image}')  -- /usr/bin/gather 
[must-gather      ] OUT Using must-gather plug-in image: quay.io/vimalkum/kepler-operator:0.0.0-must-gather
When opening a support case, bugzilla, or issue please include the following summary data along with any other requested information:
ClusterID: 1f7b621c-7e7a-4ca8-81d5-f49ad9d9acb6
ClusterVersion: Stable at "4.13.12"
ClusterOperators:
	clusteroperator/cloud-credential is missing
	clusteroperator/cluster-autoscaler is missing
	clusteroperator/insights is missing
	clusteroperator/monitoring is missing
	clusteroperator/storage is missing


[must-gather      ] OUT namespace/openshift-must-gather-t75p4 created
[must-gather      ] OUT clusterrolebinding.rbac.authorization.k8s.io/must-gather-llgwf created
[must-gather      ] OUT pod for plug-in image quay.io/vimalkum/kepler-operator:0.0.0-must-gather created
[must-gather-mjjlz] POD 2023-10-03T09:38:03.616361057Z must-gather logs are located at: '/must-gather/gather-debug.log'
[must-gather-mjjlz] POD 2023-10-03T09:38:03.616361057Z powermon must-gather started...
[must-gather-mjjlz] POD 2023-10-03T09:38:03.629416554Z 2023-10-03 09:38:03 getting kepler instance
[must-gather-mjjlz] POD 2023-10-03T09:38:05.108103126Z 2023-10-03 09:38:05 getting openshift-kepler-operator events
[must-gather-mjjlz] POD 2023-10-03T09:38:05.697635288Z 2023-10-03 09:38:05 getting kepler exporter daemonset
[must-gather-mjjlz] POD 2023-10-03T09:38:06.905154905Z 2023-10-03 09:38:06 getting kepler exporter config map
[must-gather-mjjlz] POD 2023-10-03T09:38:07.653189798Z 2023-10-03 09:38:07 getting kepler exporter service account
[must-gather-mjjlz] POD 2023-10-03T09:38:08.162324862Z 2023-10-03 09:38:08 getting kepler exporter service account
[must-gather-mjjlz] POD 2023-10-03T09:38:08.785281522Z 2023-10-03 09:38:08 running gather script for kepler pod: kepler-exporter-ds-h26gp
[must-gather-mjjlz] POD 2023-10-03T09:38:08.864821711Z 2023-10-03 09:38:08 collecting pod yaml for kepler pod: kepler-exporter-ds-h26gp
[must-gather-mjjlz] POD 2023-10-03T09:38:09.663837981Z 2023-10-03 09:38:09 collecting information from "cpuid" from kepler pod: kepler-exporter-ds-h26gp
[must-gather-mjjlz] POD 2023-10-03T09:38:10.371721220Z 2023-10-03 09:38:10 collecting environment variables from kepler pod: kepler-exporter-ds-h26gp
[must-gather-mjjlz] POD 2023-10-03T09:38:11.223976399Z 2023-10-03 09:38:11 collecting kernel version from kepler pod: kepler-exporter-ds-h26gp
[must-gather-mjjlz] POD 2023-10-03T09:38:12.969152179Z 2023-10-03 09:38:12 collecting ebpf information from kepler pod: kepler-exporter-ds-h26gp
[must-gather-mjjlz] POD 2023-10-03T09:38:14.204599060Z 2023-10-03 09:38:14 collecting logs from kepler pod: kepler-exporter-ds-h26gp
[must-gather-mjjlz] POD 2023-10-03T09:38:14.821072700Z 2023-10-03 09:38:14 running gather script for olm
[must-gather-mjjlz] POD 2023-10-03T09:38:14.914602992Z 2023-10-03 09:38:14 collecting olm info for kepler-operator
[must-gather-mjjlz] POD 2023-10-03T09:38:18.226907411Z 2023-10-03 09:38:18 collecting olm summary
[must-gather-mjjlz] POD 2023-10-03T09:38:19.342571734Z 2023-10-03 09:38:19 getting kepler-operator info
[must-gather-mjjlz] POD 2023-10-03T09:38:19.380959531Z 2023-10-03 09:38:19 collecting subscription info for kepler-operator
[must-gather-mjjlz] POD 2023-10-03T09:38:19.839823768Z 2023-10-03 09:38:19 collecting catalogsource info for kepler-operator
[must-gather-mjjlz] POD 2023-10-03T09:38:20.203048340Z 2023-10-03 09:38:20 collecting installplan info for kepler-operator
[must-gather-mjjlz] POD 2023-10-03T09:38:20.930806572Z 2023-10-03 09:38:20 collecting CSV for kepler-operator
[must-gather-mjjlz] POD 2023-10-03T09:38:24.948783859Z 2023-10-03 09:38:24 collecting deployment info for kepler-operator
[must-gather-mjjlz] POD 2023-10-03T09:38:29.524788569Z 2023-10-03 09:38:29 collecting pod info for kepler-operator
[must-gather-mjjlz] POD 2023-10-03T09:38:48.171054954Z powermon must-gather completed
[must-gather-mjjlz] OUT waiting for gather to complete
[must-gather-mjjlz] OUT downloading gather output
[must-gather-mjjlz] OUT receiving incremental file list
[must-gather-mjjlz] OUT ./
[must-gather-mjjlz] OUT gather-debug.log
[must-gather-mjjlz] OUT kepler-exporter-cm.yaml
[must-gather-mjjlz] OUT kepler-exporter-ds.yaml
[must-gather-mjjlz] OUT kepler-exporter-sa.yaml
[must-gather-mjjlz] OUT kepler-exporter-scc.yaml
[must-gather-mjjlz] OUT kepler.yaml
[must-gather-mjjlz] OUT openshift-kepler-operator_events
[must-gather-mjjlz] OUT kepler-info/
[must-gather-mjjlz] OUT kepler-info/kepler-exporter-ds-h26gp/
[must-gather-mjjlz] OUT kepler-info/kepler-exporter-ds-h26gp/ebpf-info
[must-gather-mjjlz] OUT kepler-info/kepler-exporter-ds-h26gp/env-variables
[must-gather-mjjlz] OUT kepler-info/kepler-exporter-ds-h26gp/kepler-pod.yaml
[must-gather-mjjlz] OUT kepler-info/kepler-exporter-ds-h26gp/kepler.log
[must-gather-mjjlz] OUT kepler-info/kepler-exporter-ds-h26gp/kernel-info
[must-gather-mjjlz] OUT kepler-info/kepler-exporter-ds-h26gp/node-cpuid-info
[must-gather-mjjlz] OUT kepler-operator-info/
[must-gather-mjjlz] OUT kepler-operator-info/kepler-operator-catalogsource.yaml
[must-gather-mjjlz] OUT kepler-operator-info/kepler-operator-csv.yaml
[must-gather-mjjlz] OUT kepler-operator-info/kepler-operator-deployment.yaml
[must-gather-mjjlz] OUT kepler-operator-info/kepler-operator-installplan.yaml
[must-gather-mjjlz] OUT kepler-operator-info/kepler-operator-subscription.yaml
[must-gather-mjjlz] OUT kepler-operator-info/kepler-operator.yaml
[must-gather-mjjlz] OUT kepler-operator-info/summary.txt
[must-gather-mjjlz] OUT olm-info/
[must-gather-mjjlz] OUT olm-info/olm-reources.yaml
[must-gather-mjjlz] OUT olm-info/summary.txt
[must-gather-mjjlz] OUT 
[must-gather-mjjlz] OUT sent 469 bytes  received 137,494 bytes  30,658.44 bytes/sec
[must-gather-mjjlz] OUT total size is 592,732  speedup is 4.30
[must-gather      ] OUT namespace/openshift-must-gather-t75p4 deleted
[must-gather      ] OUT clusterrolebinding.rbac.authorization.k8s.io/must-gather-llgwf deleted


Reprinting Cluster State:
When opening a support case, bugzilla, or issue please include the following summary data along with any other requested information:
ClusterID: 1f7b621c-7e7a-4ca8-81d5-f49ad9d9acb6
ClusterVersion: Stable at "4.13.12"
ClusterOperators:
	clusteroperator/cloud-credential is missing
	clusteroperator/cluster-autoscaler is missing
	clusteroperator/insights is missing
	clusteroperator/monitoring is missing
	clusteroperator/storage is missing


```