### PR TITLE
fix: promql used in openshift dashboards

### DIFF
--- a/pkg/components/exporter/assets/dashboards/power-monitoring-by-ns.json
+++ b/pkg/components/exporter/assets/dashboards/power-monitoring-by-ns.json
@@ -81,17 +81,17 @@
         {
           "datasource": "prometheus",
           "editorMode": "code",
-          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_package_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
+          "expr": "sum by (pod_name) (irate(kepler_container_package_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{pod_name}} / {{container_namespace}} / PKG",
+          "legendFormat": "{{pod_name}}",
           "range": true,
           "refId": "A"
         }
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "Pod/Process (PKG) Power Consumption (W)",
+      "title": "PKG Power Consumption (W) by Pods",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -173,17 +173,17 @@
         {
           "datasource": "prometheus",
           "editorMode": "code",
-          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_dram_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
+          "expr": "sum by (pod_name) (irate(kepler_container_dram_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{pod_name}} / {{container_namespace}} / DRAM",
+          "legendFormat": "{{pod_name}}",
           "range": true,
           "refId": "A"
         }
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "Pod/Process (DRAM) Power Consumption (W)",
+      "title": "DRAM Power Consumption (W) by Pods",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -265,17 +265,17 @@
         {
           "datasource": "prometheus",
           "editorMode": "code",
-          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
+          "expr": "sum by (pod_name) (irate(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{pod_name}} / {{container_namespace}} / GPU",
+          "legendFormat": "{{pod_name}}",
           "range": true,
           "refId": "A"
         }
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "Pod/Process (GPU) Power Consumption (W)",
+      "title": "GPU Power Consumption (W) by Pods",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -351,17 +351,17 @@
         {
           "datasource": "prometheus",
           "editorMode": "code",
-          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
+          "expr": "sum by (pod_name) (irate(kepler_other_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{pod_name}} / {{container_namespace}} / OTHER",
+          "legendFormat": "{{pod_name}} }}",
           "range": true,
           "refId": "A"
         }
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "Pod/Process (OTHER) Power Consumption (W)",
+      "title": "OTHER Power Consumption (W) by Pods",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -459,7 +459,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum(irate(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1m])))",
+          "expr": "sum(irate(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1m]))",
           "hide": false,
           "interval": "",
           "legendFormat": "DRAM",
@@ -472,7 +472,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10,sum(irate(kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\"}[1m])))",
+          "expr": "sum(irate(kepler_container_other_joules_total{container_namespace=~\"$namespace\"}[1m]))",
           "hide": false,
           "legendFormat": "OTHER",
           "range": true,
@@ -484,7 +484,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum(irate(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[1m])))",
+          "expr": "sum(irate(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[1m]))",
           "hide": false,
           "legendFormat": "GPU",
           "range": true,
@@ -578,10 +578,10 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum(\n  (increase(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *0.000000277777777777778\n  ) *\n  (count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n))",
+          "expr": "sum(increase(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h:15s])) * 0.000000277777777777778",
           "hide": false,
           "interval": "",
-          "legendFormat": "PKG (CORE+UNCORE)",
+          "legendFormat": "PKG (CORE + UNCORE)",
           "range": true,
           "refId": "A"
         },
@@ -591,7 +591,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum(\n  (increase(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *0.000000277777777777778\n  ) *\n  (count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n))",
+          "expr": "sum(increase(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h:15s])) * 0.000000277777777777778",
           "hide": false,
           "interval": "",
           "legendFormat": "DRAM",
@@ -604,7 +604,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum(\n  (increase(\n    kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *0.000000277777777777778\n  ) *\n  (count_over_time(\n    kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(\n      kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n))",
+          "expr": "sum(increase(kepler_container_other_joules_total{container_namespace=~\"$namespace\"}[1h:15s])) * 0.000000277777777777778",
           "hide": false,
           "legendFormat": "OTHER",
           "range": true,
@@ -616,7 +616,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum(\n  (increase(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *0.000000277777777777778\n  ) *\n  (count_over_time(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n))",
+          "expr": "sum(increase(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[1h:15s])) * 0.000000277777777777778",
           "hide": false,
           "legendFormat": " GPU",
           "range": true,
@@ -625,7 +625,7 @@
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "Total Power Consumption (kWh per day) in Namespace",
+      "title": "Total Energy Consumption in Namespace (kWh) - Last 1 hour",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -657,7 +657,9 @@
   "refresh": "",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": ["kepler-mixin"],
+  "tags": [
+    "kepler-mixin"
+  ],
   "templating": {
     "list": [
       {

--- a/pkg/components/exporter/assets/dashboards/power-monitoring-overview.json
+++ b/pkg/components/exporter/assets/dashboards/power-monitoring-overview.json
@@ -69,7 +69,9 @@
       "options": {
         "footer": {
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
@@ -126,7 +128,7 @@
           "refId": "A"
         }
       ],
-      "title": "CPU architecture / Monitored Nodes",
+      "title": "CPU Architecture by Nodes",
       "type": "table"
     },
     {
@@ -167,7 +169,9 @@
       "options": {
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -182,12 +186,12 @@
             "type": "prometheus",
             "uid": "To6-2So4k"
           },
-          "expr": " sum(sum by (container_namespace) (\n  (increase(kepler_container_joules_total{container_namespace=~\".*\"}[1h])\n    * 0.000000277777777777778\n  ) *\n  (count_over_time(kepler_container_joules_total{container_namespace=~\".*\"}[24h])/\n    count_over_time(kepler_container_joules_total{container_namespace=~\".*\"}[1h])\n  )\n))",
+          "expr": "sum(increase(kepler_container_joules_total{}[24h:1m])) * 0.000000277777777777778",
           "refId": "A"
         }
       ],
       "postfix": " kWh",
-      "title": "Total Energy Consumption - Last 24 hours",
+      "title": "Total Energy Consumption (kWh) - Last 24 hours",
       "type": "gauge"
     },
     {
@@ -233,7 +237,9 @@
       "options": {
         "footer": {
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
@@ -285,7 +291,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum by (container_namespace) (\n  (increase(kepler_container_package_joules_total{container_namespace=~\".*\"}[1h])\n    *0.000000277777777777778\n  ) *\n  (count_over_time(kepler_container_package_joules_total{container_namespace=~\".*\"}[24h])/\n    count_over_time(kepler_container_package_joules_total{container_namespace=~\".*\"}[1h])\n  )\n)\n+\nsum by (container_namespace) (\n  (increase(kepler_container_dram_joules_total{container_namespace=~\".*\"}[1h])\n    *0.000000277777777777778\n  ) *\n  (count_over_time(kepler_container_dram_joules_total{container_namespace=~\".*\"}[24h])/\n    count_over_time(kepler_container_dram_joules_total{container_namespace=~\".*\"}[1h])\n  )\n))",
+          "expr": "topk(10, sum by(container_namespace) (increase(kepler_container_joules_total{}[24h:1m]))) * 0.000000277777777777778",
           "format": "table",
           "interval": "",
           "legendFormat": "{{container_namespace}}",
@@ -293,14 +299,16 @@
           "refId": "A"
         }
       ],
-      "title": "Total Power Consumption for Top 10 Namespaces (kWh per day) - Last 24 hours",
+      "title": "Top 10 Energy Consuming Namespaces (kWh) in Last 24 hours",
       "type": "table"
     }
   ],
   "refresh": "",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": ["kepler-mixin"],
+  "tags": [
+    "kepler-mixin"
+  ],
   "templating": {
     "list": [
       {
@@ -328,7 +336,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Power Monitoring / Overview",
+  "title": "Power Monitoring /  Overview",
   "uid": "125cb5f5fdbea19c3067b2b34e897ad5d2b40a52",
   "version": 4,
   "weekStart": ""


### PR DESCRIPTION
This commits brings in the fixes added to kepler repo by PR: https://github.com/sustainable-computing-io/kepler/pull/948

Following changes are also made
* remove repeated namespace from all legends
* make Overview as the first item in the dropdown list by adding a space before ` O`verview