### PR TITLE
feat(dashboard): use prometheus recording rules faster queries

### DIFF
--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.8.0
-    createdAt: "2023-09-20T10:50:40Z"
+    createdAt: "2023-10-04T05:20:33Z"
     description: 'Deploys and Manages Kepler on Kubernetes '
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -136,6 +136,7 @@ spec:
         - apiGroups:
           - monitoring.coreos.com
           resources:
+          - prometheusrules
           - servicemonitors
           verbs:
           - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -58,6 +58,7 @@ rules:
 - apiGroups:
   - monitoring.coreos.com
   resources:
+  - prometheusrules
   - servicemonitors
   verbs:
   - create

--- a/pkg/components/exporter/assets/dashboards/power-monitoring-by-ns.json
+++ b/pkg/components/exporter/assets/dashboards/power-monitoring-by-ns.json
@@ -81,7 +81,7 @@
         {
           "datasource": "prometheus",
           "editorMode": "code",
-          "expr": "sum by (pod_name) (irate(kepler_container_package_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
+          "expr": "kepler:container_package_watts:1m:by_ns_pod{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod_name}}",
@@ -173,7 +173,7 @@
         {
           "datasource": "prometheus",
           "editorMode": "code",
-          "expr": "sum by (pod_name) (irate(kepler_container_dram_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
+          "expr": "kepler:container_dram_watts:1m:by_ns_pod{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod_name}}",
@@ -265,7 +265,7 @@
         {
           "datasource": "prometheus",
           "editorMode": "code",
-          "expr": "sum by (pod_name) (irate(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
+          "expr": "sum by (pod_name) (kepler:container_gpu_watts:1m:by_ns_pod{container_namespace=~\"$namespace\", pod_name=~\"$pod\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod_name}}",
@@ -351,7 +351,7 @@
         {
           "datasource": "prometheus",
           "editorMode": "code",
-          "expr": "sum by (pod_name) (irate(kepler_other_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
+          "expr": "sum by (pod_name) (kepler:other_joules_watts:1m:by_ns_pod{container_namespace=~\"$namespace\", pod_name=~\"$pod\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod_name}} }}",
@@ -446,7 +446,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum(irate(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1m])))",
+          "expr": "sum(kepler:container_package_watts:1m:by_ns_pod{container_namespace=~\"$namespace\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "PKG",
@@ -459,7 +459,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(irate(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1m]))",
+          "expr": "sum(kepler:container_dram_watts:1m:by_ns_pod{container_namespace=~\"$namespace\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "DRAM",
@@ -472,7 +472,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(irate(kepler_container_other_joules_total{container_namespace=~\"$namespace\"}[1m]))",
+          "expr": "sum(kepler:container_other_watts:1m:by_ns_pod{container_namespace=~\"$namespace\"})",
           "hide": false,
           "legendFormat": "OTHER",
           "range": true,
@@ -484,7 +484,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(irate(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[1m]))",
+          "expr": "sum(kepler:container_gpu_watts:1m:by_ns_pod{container_namespace=~\"$namespace\"})",
           "hide": false,
           "legendFormat": "GPU",
           "range": true,
@@ -578,7 +578,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h:15s])) * 0.000000277777777777778",
+          "expr": "kepler:container_package_joules_total:consumed:1h:by_ns{container_namespace=~\"$namespace\"} * 0.000000277777777777778",
           "hide": false,
           "interval": "",
           "legendFormat": "PKG (CORE + UNCORE)",
@@ -591,7 +591,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h:15s])) * 0.000000277777777777778",
+          "expr": "kepler:container_dram_joules_total:consumed:1h:by_ns{container_namespace=~\"$namespace\"} * 0.000000277777777777778",
           "hide": false,
           "interval": "",
           "legendFormat": "DRAM",
@@ -604,7 +604,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(kepler_container_other_joules_total{container_namespace=~\"$namespace\"}[1h:15s])) * 0.000000277777777777778",
+          "expr": "kepler:container_other_joules_total:consumed:1h:by_ns{container_namespace=~\"$namespace\"} * 0.000000277777777777778",
           "hide": false,
           "legendFormat": "OTHER",
           "range": true,
@@ -616,7 +616,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[1h:15s])) * 0.000000277777777777778",
+          "expr": "kepler:container_gpu_joules_total:consumed:1h:by_ns{container_namespace=~\"$namespace\"} * 0.000000277777777777778",
           "hide": false,
           "legendFormat": " GPU",
           "range": true,

--- a/pkg/components/exporter/assets/dashboards/power-monitoring-overview.json
+++ b/pkg/components/exporter/assets/dashboards/power-monitoring-overview.json
@@ -186,7 +186,7 @@
             "type": "prometheus",
             "uid": "To6-2So4k"
           },
-          "expr": "sum(increase(kepler_container_joules_total{}[24h:1m])) * 0.000000277777777777778",
+          "expr": "kepler:container_joules_total:consumed:24h:all * 0.000000277777777777778",
           "refId": "A"
         }
       ],
@@ -291,7 +291,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum by(container_namespace) (increase(kepler_container_joules_total{}[24h:1m]))) * 0.000000277777777777778",
+          "expr": "topk(10, kepler:container_joules_total:consumed:24h:by_ns) * 0.000000277777777777778",
           "format": "table",
           "interval": "",
           "legendFormat": "{{container_namespace}}",

--- a/pkg/controllers/kepler.go
+++ b/pkg/controllers/kepler.go
@@ -55,7 +55,7 @@ type KeplerReconciler struct {
 // RBAC for running Kepler exporter
 //+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=list;watch;create;update;patch;delete;use
-//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=list;watch;create;update;patch;delete
 
 // RBAC required by Kepler exporter
 //+kubebuilder:rbac:groups=core,resources=nodes/metrics;nodes/proxy;nodes/stats,verbs=get;list;watch
@@ -424,6 +424,7 @@ func exporterReconcilers(k *v1alpha1.Kepler, cluster k8s.Cluster) []reconciler.R
 		exporter.NewDaemonSet(components.Full, k),
 		exporter.NewService(k),
 		exporter.NewServiceMonitor(),
+		exporter.NewPrometheusRule(),
 	)
 
 	if cluster == k8s.OpenShift {


### PR DESCRIPTION
This commit improves the rendering of dashboards by taking advantage of Prometheus recording rules to pre-compute queries which may otherwise take too much memory (resulting in Prometheus OOM crash) or time for the query to execute.

The Operator deploy a `PrometheusRule` resource which pre-computes queries used in openshift dashboards.

<img width="1620" alt="image" src="https://github.com/sustainable-computing-io/kepler-operator/assets/3005132/5c244287-b4c3-4fe5-af07-74dda9c38220">

<img width="1620" alt="image" src="https://github.com/sustainable-computing-io/kepler-operator/assets/3005132/356a3871-5dd3-48f1-afc5-9d4e9c10a52d">
