### PR TITLE
feat(kepler): upgrade to kepler 0.6 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ GOARCH := $(shell go env GOARCH)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= $(shell cat VERSION)
 
-KEPLER_VERSION ?=release-0.5.5
+KEPLER_VERSION ?=release-0.6.1
 
 # IMG_BASE defines the docker.io namespace and part of the image name for remote images.
 # This variable is used to construct full image tags for bundle and catalog images.

--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.8.2
-    createdAt: "2023-10-11T07:41:38Z"
+    createdAt: "2023-10-12T23:35:33Z"
     description: 'Deploys and Manages Kepler on Kubernetes '
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -229,7 +229,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_KEPLER
-                  value: quay.io/sustainable_computing_io/kepler:release-0.5.5
+                  value: quay.io/sustainable_computing_io/kepler:release-0.6.1
                 image: quay.io/sustainable_computing_io/kepler-operator:0.8.2
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
@@ -332,7 +332,7 @@ spec:
     name: Kepler Operator Contributors
     url: https://sustainable-computing.io/
   relatedImages:
-  - image: quay.io/sustainable_computing_io/kepler:release-0.5.5
+  - image: quay.io/sustainable_computing_io/kepler:release-0.6.1
     name: kepler
   replaces: kepler-operator.v0.8.1
   version: 0.8.2

--- a/pkg/components/exporter/exporter.go
+++ b/pkg/components/exporter/exporter.go
@@ -137,8 +137,9 @@ func NewDaemonSet(detail components.Detail, k *v1alpha1.Kepler) *appsv1.DaemonSe
 						Command: []string{
 							"/usr/bin/kepler",
 							"-address", bindAddress,
-							"-enable-gpu=$(ENABLE_GPU)",
 							"-enable-cgroup-id=true",
+							"-expose-estimated-idle-power=true",
+							"-enable-gpu=$(ENABLE_GPU)",
 							"-v=$(KEPLER_LOG_LEVEL)",
 							"-kernel-source-dir=/usr/share/kepler/kernel_sources",
 							"-redfish-cred-file-path=/etc/redfish/redfish.csv",


### PR DESCRIPTION
Note for future maintainers
We skipped 0.6.0 release of kepler due to https://github.com/sustainable-computing-io/kepler/issues/973 
