### PR TITLE
fix(kind): ensure prometheus can discover all services

### DIFF
--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -75,6 +75,9 @@ cluster_prereqs() {
 
 	info "Ensure openshift namespace for dashboard exists"
 	run kubectl create namespace openshift-config-managed
+
+	info "Ensure prometheus can monitor all namespaces"
+	run kubectl create -f hack/monitoring/rbac
 }
 
 ensure_all_tools() {

--- a/hack/monitoring/rbac/prometheus-cr.yaml
+++ b/hack/monitoring/rbac/prometheus-cr.yaml
@@ -1,0 +1,25 @@
+# NOTE: prometheus itself requires these rbac for service discovery
+# ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/rbac.md#prometheus-rbac
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-discovery
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/metrics
+  - services
+  - endpoints
+  - pods
+  - configmaps
+  - secrets
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]

--- a/hack/monitoring/rbac/prometheus-k8s-full-crb.yaml
+++ b/hack/monitoring/rbac/prometheus-k8s-full-crb.yaml
@@ -1,0 +1,15 @@
+# NOTE: prometheus itself requires these rbac for service discovery
+# ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/rbac.md#prometheus-rbac
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-k8s-full
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-discovery
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: monitoring


### PR DESCRIPTION
Previously, prometheus deployed to monitoring namespace wasn't able to discover kepler deployed to `openshift-kepler-operator` because it lacked the rbac to discover services outside `monitoring` namespace. This commit fixes it by adding additional rbac rules allowing all services to be discovered.