### PR TITLE
fix(api): define default toleration in Kepler CRD

### DIFF
--- a/bundle/manifests/kepler.system.sustainable.computing.io_keplers.yaml
+++ b/bundle/manifests/kepler.system.sustainable.computing.io_keplers.yaml
@@ -82,6 +82,11 @@ spec:
                         minimum: 1
                         type: integer
                       tolerations:
+                        default:
+                        - effect: ""
+                          key: ""
+                          operator: Exists
+                          value: ""
                         description: If specified, define Pod's tolerations
                         items:
                           description: The pod this Toleration is attached to tolerates

--- a/config/crd/bases/kepler.system.sustainable.computing.io_keplers.yaml
+++ b/config/crd/bases/kepler.system.sustainable.computing.io_keplers.yaml
@@ -82,6 +82,11 @@ spec:
                         minimum: 1
                         type: integer
                       tolerations:
+                        default:
+                        - effect: ""
+                          key: ""
+                          operator: Exists
+                          value: ""
                         description: If specified, define Pod's tolerations
                         items:
                           description: The pod this Toleration is attached to tolerates

--- a/docs/api.md
+++ b/docs/api.md
@@ -163,6 +163,8 @@ KeplerSpec defines the desired state of Kepler
         <td>[]object</td>
         <td>
           If specified, define Pod's tolerations<br/>
+          <br/>
+            <i>Default</i>: [map[effect: key: operator:Exists value:]]<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/pkg/api/v1alpha1/kepler_types.go
+++ b/pkg/api/v1alpha1/kepler_types.go
@@ -105,6 +105,7 @@ type ExporterDeploymentSpec struct {
 
 	// If specified, define Pod's tolerations
 	// +optional
+	// +kubebuilder:default={{"key": "", "operator": "Exists", "value": "", "effect": ""}}
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 

--- a/pkg/components/exporter/exporter.go
+++ b/pkg/components/exporter/exporter.go
@@ -81,11 +81,6 @@ var (
 		"kubernetes.io/os": "linux",
 	}
 
-	// Default Toleration is allow all nodes
-	defaultTolerations = []corev1.Toleration{{
-		Operator: corev1.TolerationOpExists,
-	}}
-
 	//go:embed assets/dashboards/power-monitoring-overview.json
 	overviewDashboardJson string
 
@@ -107,11 +102,7 @@ func NewDaemonSet(detail components.Detail, k *v1alpha1.Kepler) *appsv1.DaemonSe
 
 	deployment := k.Spec.Exporter.Deployment
 	nodeSelector := deployment.NodeSelector
-
 	tolerations := deployment.Tolerations
-	if len(tolerations) == 0 {
-		tolerations = defaultTolerations
-	}
 
 	bindAddress := "0.0.0.0:" + strconv.Itoa(int(deployment.Port))
 

--- a/pkg/components/exporter/exporter_test.go
+++ b/pkg/components/exporter/exporter_test.go
@@ -54,26 +54,25 @@ func TestTolerations(t *testing.T) {
 		spec        v1alpha1.ExporterSpec
 		tolerations []corev1.Toleration
 		scenario    string
-	}{
-		{
-			spec: v1alpha1.ExporterSpec{},
-			tolerations: []corev1.Toleration{{
-				Operator: corev1.TolerationOpExists}},
-			scenario: "default case",
-		},
-		{
-			spec: v1alpha1.ExporterSpec{
-				Deployment: v1alpha1.ExporterDeploymentSpec{
-					Tolerations: []corev1.Toleration{{
-						Effect: corev1.TaintEffectNoSchedule, Key: "key1"}},
-				},
+	}{{
+		spec: v1alpha1.ExporterSpec{},
+		// NOTE: default toleration { "operator": "Exists" } is set by k8s API server (CRD default)
+		// see: Kepler_Reconciliation e2e test
+		tolerations: nil,
+		scenario:    "default case",
+	}, {
+		spec: v1alpha1.ExporterSpec{
+			Deployment: v1alpha1.ExporterDeploymentSpec{
+				Tolerations: []corev1.Toleration{{
+					Effect: corev1.TaintEffectNoSchedule, Key: "key1"}},
 			},
-			tolerations: []corev1.Toleration{{
-				Effect: corev1.TaintEffectNoSchedule, Key: "key1",
-			}},
-			scenario: "user defined toleration",
 		},
-	}
+		tolerations: []corev1.Toleration{{
+			Effect: corev1.TaintEffectNoSchedule, Key: "key1",
+		}},
+		scenario: "user defined toleration",
+	}}
+
 	for _, tc := range tt {
 		tc := tc
 		t.Run(tc.scenario, func(t *testing.T) {

--- a/tests/e2e/kepler_test.go
+++ b/tests/e2e/kepler_test.go
@@ -54,6 +54,9 @@ func TestKepler_Reconciliation(t *testing.T) {
 	f.AssertResourceExists(exporter.DaemonSetName, components.Namespace, &ds)
 
 	kepler := f.WaitUntilKeplerCondition("kepler", v1alpha1.Reconciled)
+	// ensure the default toleration is set
+	assert.Equal(t, []corev1.Toleration{{Operator: "Exists"}}, kepler.Spec.Exporter.Deployment.Tolerations)
+
 	reconciled, err := k8s.FindCondition(kepler.Status.Conditions, v1alpha1.Reconciled)
 	assert.NoError(t, err, "unable to get reconciled condition")
 	assert.Equal(t, reconciled.ObservedGeneration, kepler.Generation)


### PR DESCRIPTION
Previously, `kubectl get kepler -o wide` did not show the default toleration applied viz. {"operator": "Exists"}

This PR fixes it by moving the default toleration to the CRD spec itself

Fixes: https://github.com/sustainable-computing-io/kepler-operator/issues/186