### PR TITLE
fix: deletion error when deleting dashboard configmaps

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -92,9 +92,13 @@ func main() {
 			BindAddress: metricsAddr,
 		},
 		NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
-			opts.DefaultNamespaces = map[string]cache.Config{
+			cacheNs := map[string]cache.Config{
 				components.Namespace: {},
 			}
+			if openshift {
+				cacheNs[exporter.DashboardNs] = cache.Config{}
+			}
+			opts.DefaultNamespaces = cacheNs
 			return cache.New(config, opts)
 		},
 


### PR DESCRIPTION
This commit fixes following reconcilation error when deleting dashboards installed to `openshift-config-managed` namespace.
```
continue reconciliation despite error   {"name":"kepler", "error": "power-monitoring-overview (/v1, Kind=ConfigMap): deleter: timed out waiting for deletion : timed out waiting for the condition"}
continue reconciliation despite error   {"name":"kepler", "error": "power-monitoring-by-ns (/v1, Kind=ConfigMap): deleter: timed out waiting for deletion : timed out waiting for the condition"}
finalizer state                         {"name":"kepler", "reconciler": "finalizer", "deleted": true, "finalizer": true}
2023-10-06T08:24:03Z    ERROR   Reconciler error        {"controller": "kepler", "controllerGroup": "kepler.system.sustainable.computing.io", "controllerKind": "Kepler", "Kepler": {"name":"kepler"}, "namespace": "", "name": "kepler", "reconcileID": "514af8c3-7d06-4dde-ac80-daffd24c5138", "error": "power-monitoring-by-ns (/v1, Kind=ConfigMap): deleter: timed out waiting for deletion : timed out waiting for the condition"}
```
The error occurs because the client does not cache objects in `openshift-config-managed` namespace, which this commit fixes

Fixes: https://github.com/sustainable-computing-io/kepler-operator/issues/271
Signed-off-by: Sunil Thaha <sthaha@redhat.com>
