### PR TITLE
feat(ci): add support to cache tools in CI

### DIFF
--- a/.github/publish-images/action.yaml
+++ b/.github/publish-images/action.yaml
@@ -38,6 +38,9 @@ runs:
         username: ${{ inputs.registry_login }}
         password: ${{ inputs.registry_token }}
 
+    - name: Install all tools
+      uses: ./.github/tools-cache
+
     - name: Build Operator
       shell: bash
       run: |

--- a/.github/tools-cache/action.yaml
+++ b/.github/tools-cache/action.yaml
@@ -1,0 +1,21 @@
+---
+name: tools-cache
+description: Caches development tools
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@v3
+      id: tools-cache
+      with:
+        path: ./tmp/bin
+        key: ${{ runner.os }}-tools-${{ hashFiles('./.github/tools-cache') }}
+
+    - name: Install Dependencies
+      if: steps.tools-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: make tools
+
+    - name: List tools installed
+      shell: bash
+      run: |
+        ls ./tmp/bin

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -78,6 +78,10 @@ jobs:
       - uses: actions/setup-go@main
         with:
           go-version-file: go.mod
+
+      - name: Install all tools
+        uses: ./.github/tools-cache
+
       - name: bundle
         run: |
           make generate manifests bundle
@@ -100,6 +104,9 @@ jobs:
         shell: bash
         run: |
           echo "result=$(git rev-parse --short HEAD),v1alpha1" >> $GITHUB_OUTPUT
+
+      - name: Install all tools
+        uses: ./.github/tools-cache
 
       - name: build images for PR checks
         uses: ./.github/publish-images
@@ -128,7 +135,8 @@ jobs:
           go-version-file: go.mod
 
       - name: Install all tools
-        run: make tools
+        uses: ./.github/tools-cache
+
       - name: use kepler action for kind cluster build
         uses: sustainable-computing-io/kepler-action@v0.0.2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,9 @@ jobs:
         env:
           VERSION: ${{ github.event.inputs.tag }}
 
+      - name: Install all tools
+        uses: ./.github/tools-cache
+
       - name: Build Operator
         run: |
           make operator-build


### PR DESCRIPTION
This PR fixes issue #203 

CI runs:

Cache: https://github.com/vprashar2929/kepler-operator/actions/caches

Install tools: https://github.com/vprashar2929/kepler-operator/actions/runs/6529594381/job/17727500939#step:4:6

Sample run: https://github.com/vprashar2929/kepler-operator/actions/runs/6529594381