### PR TITLE
fix(test): export KUBECONFIG to oc only if set

### DIFF
--- a/pkg/utils/test/oc/runner.go
+++ b/pkg/utils/test/oc/runner.go
@@ -79,7 +79,11 @@ func (r *runner) runCmd(timeoutCh <-chan time.Time) (string, error) {
 		r.Cmd.Stdout = &outbuf
 		r.Cmd.Stderr = &errbuf
 	}
-	r.Cmd.Env = []string{fmt.Sprintf("%s=%s", "KUBECONFIG", os.Getenv("KUBECONFIG"))}
+
+	if kc := os.Getenv("KUBECONFIG"); kc != "" {
+		r.Cmd.Env = append(r.Cmd.Env, fmt.Sprintf("%s=%s", "KUBECONFIG", kc))
+	}
+
 	cmdargs := strings.Join(r.args, " ")
 	err := r.Cmd.Start()
 	if err != nil {


### PR DESCRIPTION
Previously, when KUBECONFIG is not set, instead of oc defaulting to ~/.kube/config, it uses KUBECONFIG that points no where and tests fail as follows:
```
❯ go test -v ./tests/e2e/... -run Node -count=1 -timeout=15m
=== RUN   TestNodeSelector
Running command cmd oc args [get node -o jsonpath={.items[*].metadata.name}]
    kepler_test.go:90:
                Error:          Received unexpected error: exit status 1
                Messages:       failed to get node names
    kepler_test.go:91:
                Error:          Should not be zero, but was 0
                Messages:       got zero nodes
--- FAIL: TestNodeSelector (0.08s)
panic: runtime error: index out of range [0] with length 0 [recovered]
        panic: runtime error: index out of range [0] with length 0

```

This commit fixes the issue by exporting KUBECONFIG only if it is not empty.