### PR TITLE
fix(deployment): do not use generic k8s labels

### DIFF
--- a/bundle/manifests/kepler-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/kepler-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/part-of: kepler-operator
-    control-plane: controller-manager
   name: kepler-operator-controller-manager-metrics-monitor
 spec:
   endpoints:
@@ -17,4 +16,3 @@ spec:
     matchLabels:
       app.kubernetes.io/name: service
       app.kubernetes.io/part-of: kepler-operator
-      control-plane: controller-manager

--- a/bundle/manifests/kepler-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/kepler-operator-controller-manager-metrics-service_v1_service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: service
     app.kubernetes.io/part-of: kepler-operator
-    control-plane: controller-manager
   name: kepler-operator-controller-manager-metrics-service
 spec:
   ports:
@@ -18,6 +17,7 @@ spec:
     protocol: TCP
     targetPort: metrics
   selector:
-    control-plane: controller-manager
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/instance: controller-manager
 status:
   loadBalancer: {}

--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.9.0
-    createdAt: "2023-10-13T05:19:02Z"
+    createdAt: "2023-10-18T07:39:41Z"
     description: 'Deploys and Manages Kepler on Kubernetes '
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -183,25 +183,26 @@ spec:
       deployments:
       - label:
           app.kubernetes.io/component: manager
-          app.kubernetes.io/created-by: kepler-operator
           app.kubernetes.io/instance: controller-manager
-          app.kubernetes.io/managed-by: kustomize
           app.kubernetes.io/name: deployment
           app.kubernetes.io/part-of: kepler-operator
-          control-plane: controller-manager
         name: kepler-operator-controller-manager
         spec:
           replicas: 1
           selector:
             matchLabels:
-              control-plane: controller-manager
+              app.kubernetes.io/component: manager
+              app.kubernetes.io/instance: controller-manager
+              app.kubernetes.io/part-of: kepler-operator
           strategy: {}
           template:
             metadata:
               annotations:
                 kubectl.kubernetes.io/default-container: manager
               labels:
-                control-plane: controller-manager
+                app.kubernetes.io/component: manager
+                app.kubernetes.io/instance: controller-manager
+                app.kubernetes.io/part-of: kepler-operator
             spec:
               affinity:
                 nodeAffinity:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
     app.kubernetes.io/name: namespace
     app.kubernetes.io/instance: system
     app.kubernetes.io/component: manager
@@ -17,24 +16,25 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: controller-manager
     app.kubernetes.io/name: deployment
     app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: kepler-operator
     app.kubernetes.io/part-of: kepler-operator
-    app.kubernetes.io/managed-by: kustomize
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/instance: controller-manager
+      app.kubernetes.io/component: manager
+      app.kubernetes.io/part-of: kepler-operator
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        app.kubernetes.io/instance: controller-manager
+        app.kubernetes.io/component: manager
+        app.kubernetes.io/part-of: kepler-operator
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution. 

--- a/config/manifests/bases/kepler-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kepler-operator.clusterserviceversion.yaml
@@ -178,25 +178,26 @@ spec:
       deployments:
       - label:
           app.kubernetes.io/component: manager
-          app.kubernetes.io/created-by: kepler-operator
           app.kubernetes.io/instance: controller-manager
-          app.kubernetes.io/managed-by: kustomize
           app.kubernetes.io/name: deployment
           app.kubernetes.io/part-of: kepler-operator
-          control-plane: controller-manager
         name: kepler-operator-controller-manager
         spec:
           replicas: 1
           selector:
             matchLabels:
-              control-plane: controller-manager
+              app.kubernetes.io/component: manager
+              app.kubernetes.io/instance: controller-manager
+              app.kubernetes.io/part-of: kepler-operator
           strategy: {}
           template:
             metadata:
               annotations:
                 kubectl.kubernetes.io/default-container: manager
               labels:
-                control-plane: controller-manager
+                app.kubernetes.io/component: manager
+                app.kubernetes.io/instance: controller-manager
+                app.kubernetes.io/part-of: kepler-operator
             spec:
               affinity:
                 nodeAffinity:

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
     app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/instance: controller-manager-metrics-monitor
     app.kubernetes.io/component: metrics
@@ -20,4 +19,3 @@ spec:
     matchLabels:
       app.kubernetes.io/name: service
       app.kubernetes.io/part-of: kepler-operator
-      control-plane: controller-manager

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
     app.kubernetes.io/name: service
     app.kubernetes.io/instance: controller-manager-metrics-service
     app.kubernetes.io/component: kube-rbac-proxy
@@ -18,4 +17,5 @@ spec:
     protocol: TCP
     targetPort: metrics
   selector:
-    control-plane: controller-manager
+      app.kubernetes.io/instance: controller-manager
+      app.kubernetes.io/component: manager

--- a/must-gather/gather
+++ b/must-gather/gather
@@ -92,6 +92,8 @@ main() {
 	esac
 
 	BASE_COLLECTION_PATH="${1:-/must-gather}"
+	# NOTE: convert relative to absolute path
+	BASE_COLLECTION_PATH="$(readlink -f "$BASE_COLLECTION_PATH")"
 	export LOGFILE_PATH="${BASE_COLLECTION_PATH}/${LOGFILE_NAME}"
 
 	mkdir -p "${BASE_COLLECTION_PATH}"

--- a/must-gather/gather-kepler-operator-info
+++ b/must-gather/gather-kepler-operator-info
@@ -52,7 +52,10 @@ get_kepler_operator_deployment_info() {
 
 get_kepler_operator_pod_info() {
 	log "getting pod info for kepler-operator"
-	run oc -n "$KEPLER_OPERATOR_NS" get pod -l control-plane=controller-manager -oyaml "$KEPLER_OPERATOR_INFO_DIR/kepler-operator.yaml"
+	run oc -n "$KEPLER_OPERATOR_NS" get pod \
+		-l app.kubernetes.io/component=manager \
+		-l app.kubernetes.io/part-of=kepler-operator \
+		-oyaml "$KEPLER_OPERATOR_INFO_DIR/kepler-operator.yaml"
 }
 
 get_summary() {
@@ -72,7 +75,10 @@ get_summary() {
 	run oc -n "$KEPLER_OPERATOR_NS" get deployment "$KEPLER_OPERATOR_DEPLOY" -owide "$KEPLER_OPERATOR_INFO_DIR/summary.txt"
 	echo -e "\n" >>"$KEPLER_OPERATOR_INFO_DIR/summary.txt"
 
-	run oc -n "$KEPLER_OPERATOR_NS" get pod -l control-plane=controller-manager -owide "$KEPLER_OPERATOR_INFO_DIR/summary.txt"
+	run oc -n "$KEPLER_OPERATOR_NS" get pod \
+		-l app.kubernetes.io/component=manager \
+		-l app.kubernetes.io/part-of=kepler-operator \
+		-owide "$KEPLER_OPERATOR_INFO_DIR/summary.txt"
 }
 
 main() {


### PR DESCRIPTION
Previously, deploying operator created deployment that used generic
`control-plane: controller-manager` label. This causes external tools
(including the must-gather script) to lookup pods that can belong to
**any** deployment that has this label. This commit replaces the label
with `app.kubernetes.io/instance: controller-manager`.

Fixes: https://issues.redhat.com/browse/POWERMON-159
Signed-off-by: Sunil Thaha <sthaha@redhat.com>
