### PR TITLE
Feat: add method field to exporter spec

### DIFF
--- a/config/crd/bases/kepler.system.sustainable.computing.io_keplers.yaml
+++ b/config/crd/bases/kepler.system.sustainable.computing.io_keplers.yaml
@@ -129,6 +129,12 @@ spec:
                           type: object
                         type: array
                     type: object
+                  method:
+                    default: bcc
+                    enum:
+                    - bcc
+                    - libbpf
+                    type: string
                 type: object
             type: object
           status:

--- a/config/samples/kepler.system_v1alpha1_kepler.yaml
+++ b/config/samples/kepler.system_v1alpha1_kepler.yaml
@@ -10,4 +10,5 @@ spec:
   exporter:
     deployment:
       port: 9103
+    method: libbpf # bcc | libbpf
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -117,6 +117,16 @@ KeplerSpec defines the desired state of Kepler
           <br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>method</b></td>
+        <td>enum</td>
+        <td>
+          <br/>
+          <br/>
+            <i>Enum</i>: bcc, libbpf<br/>
+            <i>Default</i>: bcc<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 

--- a/pkg/api/v1alpha1/kepler_types.go
+++ b/pkg/api/v1alpha1/kepler_types.go
@@ -111,6 +111,11 @@ type ExporterDeploymentSpec struct {
 
 type ExporterSpec struct {
 	Deployment ExporterDeploymentSpec `json:"deployment,omitempty"`
+
+	// +kubebuilder:default="bcc"
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Enum={"bcc","libbpf"}
+	Method string `json:"method,omitempty"`
 }
 
 // KeplerSpec defines the desired state of Kepler

--- a/pkg/components/exporter/exporter.go
+++ b/pkg/components/exporter/exporter.go
@@ -106,6 +106,17 @@ func NewDaemonSet(detail components.Detail, k *v1alpha1.Kepler) *appsv1.DaemonSe
 
 	bindAddress := "0.0.0.0:" + strconv.Itoa(int(deployment.Port))
 
+	configImage := Config.Image
+
+	if configImage == "" {
+		configImage = "quay.io/sustainable_computing_io/kepler:release-0.6.1"
+	}
+
+	switch k.Spec.Exporter.Method {
+	case "libbpf":
+		configImage += "-libbpf"
+	}
+
 	return &appsv1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: appsv1.SchemeGroupVersion.String(),
@@ -133,7 +144,7 @@ func NewDaemonSet(detail components.Detail, k *v1alpha1.Kepler) *appsv1.DaemonSe
 					Containers: []corev1.Container{{
 						Name:            "kepler-exporter",
 						SecurityContext: &corev1.SecurityContext{Privileged: pointer.Bool(true)},
-						Image:           Config.Image,
+						Image:           configImage,
 						Command: []string{
 							"/usr/bin/kepler",
 							"-address", bindAddress,

--- a/pkg/components/exporter/exporter_test.go
+++ b/pkg/components/exporter/exporter_test.go
@@ -218,3 +218,40 @@ func TestSCCAllows(t *testing.T) {
 		})
 	}
 }
+
+func TestSpecMethod(t *testing.T) {
+
+	tt := []struct {
+		deploymentSpec v1alpha1.ExporterDeploymentSpec
+		method         string
+		image          string
+		scenario       string
+	}{{
+		deploymentSpec: v1alpha1.ExporterDeploymentSpec{},
+		method:         "libbpf",
+		scenario:       "libbpf",
+		image:          "quay.io/sustainable_computing_io/kepler:release-0.6.1" + "-libbpf",
+	}, {
+		deploymentSpec: v1alpha1.ExporterDeploymentSpec{},
+		method:         "bcc",
+		scenario:       "bcc",
+		image:          "quay.io/sustainable_computing_io/kepler:release-0.6.1",
+	}}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.scenario, func(t *testing.T) {
+			t.Parallel()
+			k := v1alpha1.Kepler{
+				Spec: v1alpha1.KeplerSpec{
+					Exporter: v1alpha1.ExporterSpec{
+						Deployment: tc.deploymentSpec,
+						Method:     tc.method,
+					},
+				},
+			}
+			actual := k8s.ContainerImageFromDS(NewDaemonSet(components.Full, &k))
+			assert.Equal(t, actual, tc.image)
+		})
+	}
+}

--- a/pkg/utils/k8s/k8s.go
+++ b/pkg/utils/k8s/k8s.go
@@ -159,3 +159,7 @@ func AllowsFromSCC(SCC *secv1.SecurityContextConstraints) SCCAllows {
 		AllowHostPorts:           SCC.AllowHostPorts,
 	}
 }
+
+func ContainerImageFromDS(ds *appsv1.DaemonSet) string {
+	return ds.Spec.Template.Spec.Containers[0].Image
+}


### PR DESCRIPTION
Addresses #195.

Adds a new enum to kepler exporter spec that allows choosing which method/image to use: bcc or libbpf.

Needs to be changed once kepler 0.7.0 is released and default will be libbpf.

Testing was a little challenging and I am not super happy with the solution and open for suggestions.
As of now, the RELATED_IMAGE_KEPLER var gets set for Config.Image and determines the image used.
This is done in main.go lines 78 & 79. As this was needed for the test, I added lines 111-113 in exporter.go to set a default in case Config.Image is empty.
However, because of this and the test, now the image & its version is hardcoded in 3 different locations which is not good.
I am open to any help here :)

Was tested manually on an OpenShift 4.11 cluster.

@sthaha: any thoughts?