### PR TITLE
feat: Use Kepler annotation to choose bcc or libbpf kepler image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ GOARCH := $(shell go env GOARCH)
 VERSION ?= $(shell cat VERSION)
 
 KEPLER_VERSION ?=release-0.6.1
+KEPLER_VERSION_LIBBPF ?=release-0.6.1-libbpf
 
 # IMG_BASE defines the docker.io namespace and part of the image name for remote images.
 # This variable is used to construct full image tags for bundle and catalog images.
@@ -39,6 +40,7 @@ OPERATOR_IMG ?= $(IMG_BASE)/kepler-operator:$(VERSION)
 ADDITIONAL_TAGS ?=
 
 KEPLER_IMG ?= $(IMG_BASE)/kepler:$(KEPLER_VERSION)
+KEPLER_IMG_LIBBPF ?= $(IMG_BASE)/kepler:$(KEPLER_VERSION_LIBBPF)
 
 # E2E_TEST_IMG defines the image:tag used for the e2e test image
 E2E_TEST_IMG ?=$(IMG_BASE)/kepler-operator-e2e:$(VERSION)
@@ -152,11 +154,11 @@ build: manifests generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: install fmt vet ## Run a controller from your host against openshift cluster
-	go run ./cmd/manager/... --kepler.image=$(KEPLER_IMG) --zap-devel --zap-log-level=8 --openshift 2>&1 | tee tmp/operator.log
+	go run ./cmd/manager/... --kepler.image=$(KEPLER_IMG) --kepler.image.libbpf=$(KEPLER_IMG_LIBBPF) --zap-devel --zap-log-level=8 --openshift 2>&1 | tee tmp/operator.log
 
 .PHONY: run-k8s
 run-k8s: install fmt vet ## Run a controller from your host against vanilla k8s cluster
-	go run ./cmd/manager/... --kepler.image=$(KEPLER_IMG) --zap-devel --zap-log-level=8  2>&1 | tee tmp/operator.log
+	go run ./cmd/manager/... --kepler.image=$(KEPLER_IMG) ---kepler.image.libbpf=$(KEPLER_IMG_LIBBPF) -zap-devel --zap-log-level=8  2>&1 | tee tmp/operator.log
 
 # docker_tag accepts an image:tag and a list of additional tags comma-separated
 # it tags the image with the additional tags
@@ -349,6 +351,7 @@ VERSION_REPLACED ?=
 bundle: generate manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	OPERATOR_IMG=$(OPERATOR_IMG) \
 	KEPLER_IMG=$(KEPLER_IMG) \
+	KEPLER_IMG_LIBBPF=$(KEPLER_IMG_LIBBPF) \
 	VERSION=$(VERSION) \
 	VERSION_REPLACED=$(VERSION_REPLACED) \
 	BUNDLE_GEN_FLAGS='$(BUNDLE_GEN_FLAGS)' \

--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.9.0
-    createdAt: "2023-10-18T07:39:41Z"
+    createdAt: "2023-10-26T11:54:02Z"
     description: 'Deploys and Manages Kepler on Kubernetes '
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -225,12 +225,15 @@ spec:
                 - --openshift
                 - --leader-elect
                 - --kepler.image=$(RELATED_IMAGE_KEPLER)
+                - --kepler.image.libbpf=$(RELATED_IMAGE_KEPLER_LIBBPF)
                 - --zap-log-level=5
                 command:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_KEPLER
                   value: quay.io/sustainable_computing_io/kepler:release-0.6.1
+                - name: RELATED_IMAGE_KEPLER_LIBBPF
+                  value: quay.io/sustainable_computing_io/kepler:release-0.6.1-libbpf
                 image: quay.io/sustainable_computing_io/kepler-operator:0.9.0
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
@@ -335,5 +338,7 @@ spec:
   relatedImages:
   - image: quay.io/sustainable_computing_io/kepler:release-0.6.1
     name: kepler
+  - image: quay.io/sustainable_computing_io/kepler:release-0.6.1-libbpf
+    name: kepler-libbpf
   replaces: kepler-operator.v0.8.2
   version: 0.9.0

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -76,7 +76,9 @@ func main() {
 
 	// NOTE: RELATED_IMAGE_KEPLER can be set as env or flag, flag takes precedence over env
 	keplerImage := os.Getenv("RELATED_IMAGE_KEPLER")
+	keplerImageLibbpf := os.Getenv("RELATED_IMAGE_KEPLER_LIBBPF")
 	flag.StringVar(&exporter.Config.Image, "kepler.image", keplerImage, "kepler image")
+	flag.StringVar(&exporter.Config.ImageLibbpf, "kepler.image.libbpf", keplerImageLibbpf, "kepler libbpf image")
 
 	opts := zap.Options{
 		Development: true,

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -71,11 +71,14 @@ spec:
         env:
           - name: RELATED_IMAGE_KEPLER
             value: '<KEPLER_IMG>'
+          - name: RELATED_IMAGE_KEPLER_LIBBPF
+            value: '<KEPLER_IMG_LIBBPF>'
         args:
         # TODO: move --openshift to openshift specific kustomize directory
         - --openshift
         - --leader-elect
         - --kepler.image=$(RELATED_IMAGE_KEPLER)
+        - --kepler.image.libbpf=$(RELATED_IMAGE_KEPLER_LIBBPF)
         - --zap-log-level=5
         image: '<OPERATOR_IMG>'
         imagePullPolicy: IfNotPresent

--- a/hack/bundle.sh
+++ b/hack/bundle.sh
@@ -66,6 +66,7 @@ main() {
 		sed \
 			-e "s|<OPERATOR_IMG>|$OPERATOR_IMG|g" \
 			-e "s|<KEPLER_IMG>|$KEPLER_IMG|g" \
+			-e "s|<KEPLER_IMG_LIBBPF>|$KEPLER_IMG_LIBBPF|g" \
 			-e "s|<OLD_BUNDLE_VERSION>|$old_bundle_version|g" |
 		tee tmp/pre-bundle.yaml |
 		operator-sdk generate bundle "${gen_opts[@]}"


### PR DESCRIPTION
This PR reads value of annotation `"app.kubernetes.io/kepler-bpf-attach-method"` on Kepler object to decide which bpf type image to be deployed.
If the value is `"libbpf"` , the image `quay.io/sustainable_computing_io/kepler:release-0.6.1-libbpf` is chosen, else `quay.io/sustainable_computing_io/kepler:release-0.6.1` is used. 

This is a temporary fix to let users choose libbpf image till kepler upstream makes libbpf as the default attach method.

fixes: https://issues.redhat.com/browse/POWERMON-166