### PR TITLE
Minor corrections and Doc changes to bpf deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,13 +152,13 @@ cluster-down: ## delete the local development cluster
 build: manifests generate fmt vet ## Build manager binary.
 	go build -o bin/manager ./cmd/manager/...
 
+OPENSHIFT ?= true
+
 .PHONY: run
 run: install fmt vet ## Run a controller from your host against openshift cluster
-	go run ./cmd/manager/... --kepler.image=$(KEPLER_IMG) --kepler.image.libbpf=$(KEPLER_IMG_LIBBPF) --zap-devel --zap-log-level=8 --openshift 2>&1 | tee tmp/operator.log
-
-.PHONY: run-k8s
-run-k8s: install fmt vet ## Run a controller from your host against vanilla k8s cluster
-	go run ./cmd/manager/... --kepler.image=$(KEPLER_IMG) ---kepler.image.libbpf=$(KEPLER_IMG_LIBBPF) -zap-devel --zap-log-level=8  2>&1 | tee tmp/operator.log
+	go run ./cmd/manager/... \
+		--kepler.image=$(KEPLER_IMG) --kepler.image.libbpf=$(KEPLER_IMG_LIBBPF) \
+		--zap-devel --zap-log-level=8 --openshift=$(OPENSHIFT) 2>&1 | tee tmp/operator.log
 
 # docker_tag accepts an image:tag and a list of additional tags comma-separated
 # it tags the image with the additional tags

--- a/config/samples/kepler.system_v1alpha1_kepler.yaml
+++ b/config/samples/kepler.system_v1alpha1_kepler.yaml
@@ -1,6 +1,9 @@
 apiVersion: kepler.system.sustainable.computing.io/v1alpha1
 kind: Kepler
 metadata:
+  # NOTE: to deploy libbpf image, you need to set the following annotation
+  # annotations:
+  #   kepler.sustainable.computing.io/bpf-attach-method: libbpf
   labels:
     app.kubernetes.io/name: kepler
     app.kubernetes.io/instance: kepler

--- a/pkg/components/exporter/exporter.go
+++ b/pkg/components/exporter/exporter.go
@@ -60,7 +60,7 @@ const (
 
 	PrometheusRuleName = prefix + "prom-rules"
 
-	KeplerBpfAttachMethodAnnotation = "app.kubernetes.io/kepler-bpf-attach-method"
+	KeplerBpfAttachMethodAnnotation = "kepler.sustainable.computing.io/bpf-attach-method"
 	KeplerBpfAttachMethodBCC        = "bcc"
 	KeplerBpfAttachMethodLibbpf     = "libbpf"
 )

--- a/pkg/components/exporter/exporter_test.go
+++ b/pkg/components/exporter/exporter_test.go
@@ -234,21 +234,21 @@ func TestBpfAttachMethod(t *testing.T) {
 		},
 		{
 			annotations: map[string]string{
-				"app.kubernetes.io/kepler-bpf-attach-method": "junk",
+				KeplerBpfAttachMethodAnnotation: "junk",
 			},
 			IsLibbpf: false,
 			scenario: "annotation present but not libbpf",
 		},
 		{
 			annotations: map[string]string{
-				"app.kubernetes.io/kepler-bpf-attach-method": "bcc",
+				KeplerBpfAttachMethodAnnotation: "bcc",
 			},
 			IsLibbpf: false,
 			scenario: "annotation present with bcc",
 		},
 		{
 			annotations: map[string]string{
-				"app.kubernetes.io/kepler-bpf-attach-method": "libbpf",
+				KeplerBpfAttachMethodAnnotation: "libbpf",
 			},
 			IsLibbpf: true,
 			scenario: "annotation present with libbpf",


### PR DESCRIPTION
This PR includes 3 minor corrections / modifications 
1. Fix `make run-k8s` which had an additional `-` in the arg by replacing both `run` and `run-k8s` with just a single `run` target `make run OPENSHIFT=[true]|false`
3. Use kepler.sustainable.computing.io namespace for kepler related annotations 
4. Add a comment in kepler sample explaining how to enable libbpf 
