### PR TITLE
Feat: export correct namespace

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -57,6 +57,7 @@ func NewKeplerNamespace() *corev1.Namespace {
 				//   allowPrivilegeEscalation != false (container "kepler-exporter" must set
 				//   securityContext.allowPrivilegeEscalation=false),
 				"pod-security.kubernetes.io/enforce": "privileged",
+				"openshift.io/cluster-monitoring":    "true",
 			}),
 			//TODO: ensure in-cluster monitoring ignores this ns
 		},

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -57,7 +57,6 @@ func NewKeplerNamespace() *corev1.Namespace {
 				//   allowPrivilegeEscalation != false (container "kepler-exporter" must set
 				//   securityContext.allowPrivilegeEscalation=false),
 				"pod-security.kubernetes.io/enforce": "privileged",
-				"openshift.io/cluster-monitoring":    "true",
 			}),
 			//TODO: ensure in-cluster monitoring ignores this ns
 		},

--- a/pkg/components/exporter/exporter.go
+++ b/pkg/components/exporter/exporter.go
@@ -489,6 +489,14 @@ func NewServiceMonitor() *monv1.ServiceMonitor {
 		TargetLabel: "instance",
 	}}
 
+	metricRelabelings := []*monv1.RelabelConfig{{
+		Action: "replace",
+		SourceLabels: []monv1.LabelName{
+			"container_namespace",
+		},
+		TargetLabel: "namespace",
+	}}
+
 	return &monv1.ServiceMonitor{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: monv1.SchemeGroupVersion.String(),
@@ -501,10 +509,11 @@ func NewServiceMonitor() *monv1.ServiceMonitor {
 		},
 		Spec: monv1.ServiceMonitorSpec{
 			Endpoints: []monv1.Endpoint{{
-				Port:           ServicePortName,
-				Interval:       "3s",
-				Scheme:         "http",
-				RelabelConfigs: relabelings,
+				Port:                 ServicePortName,
+				Interval:             "3s",
+				Scheme:               "http",
+				RelabelConfigs:       relabelings,
+				MetricRelabelConfigs: metricRelabelings,
 			}},
 			JobLabel: "app.kubernetes.io/name",
 			Selector: metav1.LabelSelector{


### PR DESCRIPTION
This PR makes the ServiceMonitor relabel namespace to have the same value as container_namespace instead of "openshift-kepler-operator" applied after scraping so that it is more straight-forward to use the metrics.

Also adds label `"openshift.io/cluster-monitoring":    "true"` so that the metrics get scraped by openshift-monitoring instead of user workload monitoring which makes usage more straight-forward. 
I am not sure if this is wanted for kepler-operator but in our use case it would be much better. In case this is not the intended behaviour, we can just revert the corresponding commit.

Was tested and works on OpenShift 4.11 cluster.

Addresses #302 