### PR TITLE
fix(test): fix e2e test

### DIFF
--- a/tests/run-e2e.sh
+++ b/tests/run-e2e.sh
@@ -146,13 +146,12 @@ run_e2e() {
 	local error_log="$LOGS_DIR/operator-errors.log"
 
 	log_events "$OPERATORS_NS" &
-	log_events "openshift-kepler-operator" &
+	log_events "kepler-operator" &
 	watch_operator_errors "$error_log" &
 
 	local ret=0
 	go test -v -failfast -timeout $TEST_TIMEOUT \
 		./tests/e2e/... \
-		-run Reconcile \
 		2>&1 | tee "$LOGS_DIR/e2e.log" || ret=1
 
 	# terminate both log_events


### PR DESCRIPTION
This PR fixes the e2e test by removing `-run Reconcile` from go test command.