### PR TITLE
fix missing UP-TO-DATE status field

### DIFF
--- a/bundle/manifests/kepler.system.sustainable.computing.io_keplerinternals.yaml
+++ b/bundle/manifests/kepler.system.sustainable.computing.io_keplerinternals.yaml
@@ -24,7 +24,7 @@ spec:
     - jsonPath: .status.exporter.currentNumberScheduled
       name: Current
       type: integer
-    - jsonPath: .status.updatedNumberScheduled
+    - jsonPath: .status.exporter.updatedNumberScheduled
       name: Up-to-date
       type: integer
     - jsonPath: .status.exporter.numberReady

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -116,6 +116,7 @@ func main() {
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
 		},
+		// TODO: add new introduced namespace from KeplerInternal.Spec.Deployment.Namespace
 		NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
 			cacheNs := map[string]cache.Config{
 				controllers.KeplerDeploymentNS: {},

--- a/config/crd/bases/kepler.system.sustainable.computing.io_keplerinternals.yaml
+++ b/config/crd/bases/kepler.system.sustainable.computing.io_keplerinternals.yaml
@@ -24,7 +24,7 @@ spec:
     - jsonPath: .status.exporter.currentNumberScheduled
       name: Current
       type: integer
-    - jsonPath: .status.updatedNumberScheduled
+    - jsonPath: .status.exporter.updatedNumberScheduled
       name: Up-to-date
       type: integer
     - jsonPath: .status.exporter.numberReady

--- a/pkg/api/v1alpha1/kepler_internal_types.go
+++ b/pkg/api/v1alpha1/kepler_internal_types.go
@@ -64,7 +64,7 @@ type KeplerInternalSpec struct {
 // +kubebuilder:printcolumn:name="Port",type=integer,JSONPath=`.spec.exporter.deployment.port`
 // +kubebuilder:printcolumn:name="Desired",type=integer,JSONPath=`.status.exporter.desiredNumberScheduled`
 // +kubebuilder:printcolumn:name="Current",type=integer,JSONPath=`.status.exporter.currentNumberScheduled`
-// +kubebuilder:printcolumn:name="Up-to-date",type=integer,JSONPath=`.status.updatedNumberScheduled`
+// +kubebuilder:printcolumn:name="Up-to-date",type=integer,JSONPath=`.status.exporter.updatedNumberScheduled`
 // +kubebuilder:printcolumn:name="Ready",type=integer,JSONPath=`.status.exporter.numberReady`
 // +kubebuilder:printcolumn:name="Available",type=integer,JSONPath=`.status.exporter.numberAvailable`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"


### PR DESCRIPTION
This PR made a small fix on status and add TODO when different namespace is introduced later by the KeplerInternal CR (not include in the command flag). 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>