### PR TITLE
fix: remove any occurrence of openshift-kepler-operator

### DIFF
--- a/hack/dashboard/assets/kepler/dashboard.json
+++ b/hack/dashboard/assets/kepler/dashboard.json
@@ -1138,8 +1138,8 @@
         "allValue": ".*",
         "current": {
           "selected": false,
-          "text": "openshift-kepler-operator",
-          "value": "openshift-kepler-operator"
+          "text": "kepler-operator",
+          "value": "kepler-operator"
         },
         "datasource": {
           "type": "prometheus",

--- a/tests/run-e2e.sh
+++ b/tests/run-e2e.sh
@@ -164,7 +164,7 @@ run_e2e() {
 	local error_log="$LOGS_DIR/operator-errors.log"
 
 	log_events "$OPERATORS_NS" &
-	log_events "openshift-kepler-operator" &
+	log_events "kepler-operator" &
 	watch_operator_errors "$error_log" &
 
 	local ret=0


### PR DESCRIPTION
This PR removes the occurrence of `openshift-kepler-operator`

**Note:** Didn't removed it from must-gather scripts. 