### PR TITLE
chore: update kepler image to release-0.7.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ GOARCH := $(shell go env GOARCH)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= $(shell cat VERSION)
 
-KEPLER_VERSION ?=release-0.6.1
-KEPLER_VERSION_LIBBPF ?=release-0.6.1-libbpf
+KEPLER_VERSION ?=release-0.7.2
+KEPLER_VERSION_LIBBPF ?=release-0.7.2
 
 # IMG_BASE and KEPLER_IMG_BASE are set to distinguish between Operator-specific images and Kepler-Specific images.
 # IMG_BASE is used for building and pushing operator related images.

--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.9.2
-    createdAt: "2023-12-08T08:56:48Z"
+    createdAt: "2023-12-22T15:01:54Z"
     description: 'Deploys and Manages Kepler on Kubernetes '
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/internal-objects: |-
@@ -251,9 +251,9 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_KEPLER
-                  value: quay.io/sustainable_computing_io/kepler:release-0.6.1
+                  value: quay.io/sustainable_computing_io/kepler:release-0.7.2
                 - name: RELATED_IMAGE_KEPLER_LIBBPF
-                  value: quay.io/sustainable_computing_io/kepler:release-0.6.1-libbpf
+                  value: quay.io/sustainable_computing_io/kepler:release-0.7.2
                 image: quay.io/sustainable_computing_io/kepler-operator:0.9.2
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
@@ -356,9 +356,7 @@ spec:
     name: Kepler Operator Contributors
     url: https://sustainable-computing.io/
   relatedImages:
-  - image: quay.io/sustainable_computing_io/kepler:release-0.6.1
+  - image: quay.io/sustainable_computing_io/kepler:release-0.7.2
     name: kepler
-  - image: quay.io/sustainable_computing_io/kepler:release-0.6.1-libbpf
-    name: kepler-libbpf
   replaces: kepler-operator.v0.9.0
   version: 0.9.2


### PR DESCRIPTION
fixes #330 

Please note that starting from release-0.7.1 libbpf is used as the default. For 0.7.1 there was a separate release-0.7.1-bcc but this is not available for 0.7.2 as of right now. Therefore, I just added release-0.7.2 for both libbpf and non-libbpf (bcc). I am not sure whether we should now invert the behavior of the "kepler.sustainable.computing.io/bpf-attach-method" annotation and make libbpf the default and bcc selectable. This could be handled in a separate issue/PR.