### PR TITLE
ci: improve model-server and estimator validation

### DIFF
--- a/pkg/components/estimator/estimator.go
+++ b/pkg/components/estimator/estimator.go
@@ -27,6 +27,7 @@ import (
 )
 
 const (
+	// NOTE: update tests/images.yaml when changing this image
 	StableImage          = "quay.io/sustainable_computing_io/kepler_model_server:v0.6"
 	waitForSocketCommand = "until [ -e /tmp/estimator.sock ]; do sleep 1; done && %s"
 )

--- a/pkg/utils/test/assertions.go
+++ b/pkg/utils/test/assertions.go
@@ -127,5 +127,6 @@ func (f Framework) AssertInternalStatus(name string) {
 	assert.Equal(f.T, available.ObservedGeneration, ki.Generation)
 	assert.Equal(f.T, available.Status, v1alpha1.ConditionTrue)
 
-	f.WaitUntilInternalHasExpectedRunning(name)
+	f.AssertModelServerStatus(name)
+	f.AssertEstimatorStatus(name)
 }

--- a/tests/images.yaml
+++ b/tests/images.yaml
@@ -1,0 +1,3 @@
+images:
+- component: 'model-server'
+  image: 'quay.io/sustainable_computing_io/kepler_model_server:v0.6'


### PR DESCRIPTION
Currently, CI fails because model-server image absent in CI and  validation does not wait enough for Model Server to be running. This is fixed by 
1. allowing additional  images to be loaded into cluster and using that to load model-server image
2. improving  the validation of model-server and estimator into 2 functions which provide each amble time to be up and running.
