### PR TITLE
feat(dashboard): show node power source info

### DIFF
--- a/pkg/components/exporter/assets/dashboards/power-monitoring-overview.json
+++ b/pkg/components/exporter/assets/dashboards/power-monitoring-overview.json
@@ -100,7 +100,31 @@
           "unit": "short"
         },
         {
-          "alias": "Number of nodes",
+          "alias": "Components Source",
+          "colors": [],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "link": true,
+          "linkTargetBlank": false,
+          "pattern": "components_power_source",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "Platform Source",
+          "colors": [],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "link": true,
+          "linkTargetBlank": false,
+          "pattern": "platform_power_source",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "Nodes",
           "colors": [],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 0,
@@ -120,7 +144,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "count by (cpu_architecture)(kepler_node_info{container=\"kepler\"}) ",
+          "expr": "count by (cpu_architecture, components_power_source, platform_power_source)(kepler_node_info{container=\"kepler\"}) ",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -128,7 +152,7 @@
           "refId": "A"
         }
       ],
-      "title": "CPU Architecture by Nodes",
+      "title": "Node - CPU Architecture & Power Source",
       "type": "table"
     },
     {


### PR DESCRIPTION
This commit adds the `components_power_source` and `platform_power_source` info to the cluster overview dashboard in OpenShift.

 
<img width="803" alt="image" src="https://github.com/sustainable-computing-io/kepler-operator/assets/3005132/544f757a-274b-4721-beac-b7c3624c2432">
