### PR TITLE
fix(test): accept deployment ns

### DIFF
--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/sustainable.computing.io/kepler-operator/pkg/controllers"
 	"github.com/sustainable.computing.io/kepler-operator/pkg/utils/k8s"
 )
 
@@ -30,6 +31,9 @@ var (
 
 func TestMain(m *testing.M) {
 	openshift := flag.Bool("openshift", true, "Indicate if tests are run aginast an OpenShift cluster.")
+	flag.StringVar(&controllers.KeplerDeploymentNS, "deployment-namespace", controllers.KeplerDeploymentNS,
+		"Namespace where kepler and its components are deployed.")
+
 	flag.Parse()
 
 	if *openshift {


### PR DESCRIPTION
This is required to support running tests when kepler is deployed to
non-default namespace. E.g. on OpenShift, it may be deployed onto a
different namespace than the default `kepler-operator`.

Signed-off-by: Sunil Thaha <sthaha@redhat.com>