### PR TITLE
fix: report failure during reconciliation correctly

### DIFF
--- a/pkg/controllers/kepler.go
+++ b/pkg/controllers/kepler.go
@@ -93,7 +93,7 @@ func (r *KeplerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	logger.V(6).Info("Running sub reconcilers", "kepler", kepler.Spec)
 
 	result, recErr := r.runKeplerReconcilers(ctx, kepler)
-	updateErr := r.updateStatus(ctx, req, err)
+	updateErr := r.updateStatus(ctx, req, recErr)
 
 	if recErr != nil {
 		return result, recErr

--- a/pkg/controllers/kepler_internal.go
+++ b/pkg/controllers/kepler_internal.go
@@ -112,7 +112,7 @@ func (r *KeplerInternalReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	logger.V(6).Info("Running sub reconcilers", "kepler-internal", ki.Spec)
 
 	result, recErr := r.runReconcilers(ctx, ki)
-	updateErr := r.updateStatus(ctx, req, err)
+	updateErr := r.updateStatus(ctx, req, recErr)
 
 	if recErr != nil {
 		return result, recErr


### PR DESCRIPTION
Previously error (recErr) while running reconcilers were ignored by both kepler and kepler-internal controllers which resulted in reporting in conditions.Reconciled as success even though it failed. The commit fixes that oversight.