### PR TITLE
feat: allow dashboard to show in OpenShift developer console

### DIFF
--- a/pkg/components/exporter/exporter.go
+++ b/pkg/components/exporter/exporter.go
@@ -137,7 +137,8 @@ func openshiftDashboardObjectMeta(name string) metav1.ObjectMeta {
 		Name:      name,
 		Namespace: DashboardNs,
 		Labels: components.CommonLabels.Merge(k8s.StringMap{
-			"console.openshift.io/dashboard": "true",
+			"console.openshift.io/dashboard":     "true",
+			"console.openshift.io/odc-dashboard": "true",
 		}),
 		Annotations: k8s.StringMap{
 			"include.release.openshift.io/self-managed-high-availability": "true",


### PR DESCRIPTION
This PR adds the label `console.openshift.io/odc-dashboard` to the dashboards config map which allows dashboards to be visible in the developer console. 

For user to see the values the user must have view permissions for the project that the dashboard is for i.e `kepler-operator`

![Screenshot 2024-03-07 at 1 09 43 PM](https://github.com/sustainable-computing-io/kepler-operator/assets/115542213/b768e2cb-c0c2-4bde-afd8-d84b7f2904b8)
