### PR TITLE
feat(redfish): reduce rbac permission given to operator and kepler for handling secrets

### DIFF
--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.10.0
-    createdAt: "2024-03-01T19:29:40Z"
+    createdAt: "2024-03-11T03:26:22Z"
     description: 'Deploys and Manages Kepler on Kubernetes '
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/internal-objects: |-
@@ -117,7 +117,6 @@ spec:
           resources:
           - daemonsets
           - deployments
-          - secrets
           verbs:
           - create
           - delete
@@ -156,9 +155,15 @@ spec:
           - nodes/metrics
           - nodes/proxy
           - nodes/stats
-          - secrets
           verbs:
           - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
           - list
           - watch
         - apiGroups:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,7 +9,6 @@ rules:
   resources:
   - daemonsets
   - deployments
-  - secrets
   verbs:
   - create
   - delete
@@ -48,9 +47,15 @@ rules:
   - nodes/metrics
   - nodes/proxy
   - nodes/stats
-  - secrets
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
   - list
   - watch
 - apiGroups:

--- a/pkg/components/exporter/exporter_test.go
+++ b/pkg/components/exporter/exporter_test.go
@@ -208,10 +208,10 @@ func TestDaemonSet(t *testing.T) {
 			actual_hostPID := k8s.HostPIDFromDS(ds)
 			assert.Equal(t, actual_hostPID, tc.hostPID)
 
-			actual_exporterCommand := k8s.CommandFromDS(ds, IdxKeplerContainer)
+			actual_exporterCommand := k8s.CommandFromDS(ds, KeplerContainerIndex)
 			assert.Equal(t, actual_exporterCommand, tc.exporterCommand)
 
-			actual_volumeMounts := k8s.VolumeMountsFromDS(ds, IdxKeplerContainer)
+			actual_volumeMounts := k8s.VolumeMountsFromDS(ds, KeplerContainerIndex)
 			assert.Equal(t, actual_volumeMounts, tc.volumeMounts)
 
 			actual_Volumes := k8s.VolumesFromDS(ds)

--- a/pkg/controllers/kepler_internal.go
+++ b/pkg/controllers/kepler_internal.go
@@ -48,12 +48,13 @@ type KeplerInternalReconciler struct {
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=*,verbs=*
 
 // RBAC for running Kepler exporter
-//+kubebuilder:rbac:groups=apps,resources=daemonsets;deployments;secrets,verbs=list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=apps,resources=daemonsets;deployments,verbs=list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=secrets,verbs=list;watch
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=list;watch;create;update;patch;delete;use
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=list;watch;create;update;patch;delete
 
 // RBAC required by Kepler exporter
-//+kubebuilder:rbac:groups=core,resources=nodes/metrics;nodes/proxy;nodes/stats;secrets,verbs=get;list;watch
+//+kubebuilder:rbac:groups=core,resources=nodes/metrics;nodes/proxy;nodes/stats,verbs=get;list;watch
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KeplerInternalReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/pkg/reconciler/kepler.go
+++ b/pkg/reconciler/kepler.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/sustainable.computing.io/kepler-operator/pkg/api/v1alpha1"
+	"github.com/sustainable.computing.io/kepler-operator/pkg/components/exporter"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type KeplerDaemonSetReconciler struct {
+	Ki v1alpha1.KeplerInternal
+	Ds *appsv1.DaemonSet
+}
+
+func (r KeplerDaemonSetReconciler) Reconcile(ctx context.Context, cli client.Client, s *runtime.Scheme) Result {
+
+	secretRef := r.Ki.Spec.Exporter.Redfish.SecretRef
+	secret, err := r.getRedfishSecret(ctx, cli, secretRef)
+
+	if err != nil {
+		return Result{Action: Stop, Error: fmt.Errorf("Error occurred while getting Redfish secret %w", err)}
+	}
+
+	if secret == nil {
+		return Result{
+			Action: Stop,
+			Error:  fmt.Errorf("Redfish secret %q configured, but not found in %q namespace", secretRef, r.Ki.Namespace()),
+		}
+	}
+	if _, ok := secret.Data[exporter.RedfishCSV]; !ok {
+		return Result{Action: Stop, Error: fmt.Errorf("Redfish secret is missing %q key", exporter.RedfishCSV)}
+	}
+
+	exporter.MountRedfishSecretToDaemonSet(r.Ds, secret)
+
+	return Updater{Owner: &r.Ki, Resource: r.Ds}.Reconcile(ctx, cli, s)
+}
+
+func (r KeplerDaemonSetReconciler) getRedfishSecret(ctx context.Context, cli client.Client, secretName string) (*corev1.Secret, error) {
+	ns := r.Ki.Spec.Exporter.Deployment.Namespace
+	redfishSecret := corev1.Secret{}
+	if err := cli.Get(ctx, types.NamespacedName{Namespace: ns, Name: secretName}, &redfishSecret); err != nil {
+		return nil, client.IgnoreNotFound(err)
+	}
+	return &redfishSecret, nil
+}
+
+type KeplerConfigMapReconciler struct {
+	Ki  v1alpha1.KeplerInternal
+	Cfm *corev1.ConfigMap
+}
+
+func (r KeplerConfigMapReconciler) Reconcile(ctx context.Context, cli client.Client, s *runtime.Scheme) Result {
+	rf := r.Ki.Spec.Exporter.Redfish
+	zero := metav1.Duration{}
+	if rf.ProbeInterval != zero {
+		r.Cfm.Data["REDFISH_PROBE_INTERVAL_IN_SECONDS"] = fmt.Sprintf("%f", rf.ProbeInterval.Duration.Seconds())
+	}
+	r.Cfm.Data["REDFISH_SKIP_SSL_VERIFY"] = strconv.FormatBool(rf.SkipSSLVerify)
+	return Updater{Owner: &r.Ki, Resource: r.Cfm}.Reconcile(ctx, cli, s)
+}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -18,16 +18,8 @@ package reconciler
 
 import (
 	"context"
-	"fmt"
-	"strconv"
 
-	"github.com/sustainable.computing.io/kepler-operator/pkg/api/v1alpha1"
-	"github.com/sustainable.computing.io/kepler-operator/pkg/components/exporter"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -51,53 +43,4 @@ type Result struct {
 
 type Reconciler interface {
 	Reconcile(context.Context, client.Client, *runtime.Scheme) Result
-}
-
-type KeplerDaemonSetReconciler struct {
-	Ki v1alpha1.KeplerInternal
-	Ds *appsv1.DaemonSet
-}
-
-func (r KeplerDaemonSetReconciler) Reconcile(ctx context.Context, cli client.Client, s *runtime.Scheme) Result {
-
-	secretRef := r.Ki.Spec.Exporter.Redfish.SecretRef
-	secret, err := r.getRedfishSecret(ctx, cli, secretRef)
-
-	if err != nil {
-		return Result{Action: Stop, Error: fmt.Errorf("Error occured while getting secret %w", err)}
-	}
-	if secret == nil {
-		return Result{Action: Stop, Error: fmt.Errorf("Redfish secret configured, but secret %q not found", secretRef)}
-	}
-	if _, ok := secret.Data[exporter.REDFISH_CSV]; !ok {
-		return Result{Action: Stop, Error: fmt.Errorf("Redfish secret does not contain \"redfish.csv\"")}
-	}
-
-	exporter.MountRedfishSecretToDaemonSet(r.Ds, secret)
-
-	return Updater{Owner: &r.Ki, Resource: r.Ds}.Reconcile(ctx, cli, s)
-}
-
-func (r KeplerDaemonSetReconciler) getRedfishSecret(ctx context.Context, cli client.Client, secretName string) (*corev1.Secret, error) {
-	ns := r.Ki.Spec.Exporter.Deployment.Namespace
-	redfishSecret := corev1.Secret{}
-	if err := cli.Get(ctx, types.NamespacedName{Namespace: ns, Name: secretName}, &redfishSecret); err != nil {
-		return nil, client.IgnoreNotFound(err)
-	}
-	return &redfishSecret, nil
-}
-
-type KeplerConfigMapReconciler struct {
-	Ki  v1alpha1.KeplerInternal
-	Cfm *corev1.ConfigMap
-}
-
-func (r KeplerConfigMapReconciler) Reconcile(ctx context.Context, cli client.Client, s *runtime.Scheme) Result {
-	rf := r.Ki.Spec.Exporter.Redfish
-	zero := metav1.Duration{}
-	if rf.ProbeInterval != zero {
-		r.Cfm.Data["REDFISH_PROBE_INTERVAL_IN_SECONDS"] = fmt.Sprintf("%f", rf.ProbeInterval.Duration.Seconds())
-	}
-	r.Cfm.Data["REDFISH_SKIP_SSL_VERIFY"] = strconv.FormatBool(rf.SkipSSLVerify)
-	return Updater{Owner: &r.Ki, Resource: r.Cfm}.Reconcile(ctx, cli, s)
 }

--- a/pkg/utils/k8s/k8s.go
+++ b/pkg/utils/k8s/k8s.go
@@ -34,6 +34,9 @@ const (
 	OpenShift
 )
 
+// ContainerIndex type represents the hard-coded index of Containers in a PodSpec
+type ContainerIndex int
+
 type StringMap map[string]string
 
 type SCCAllows struct {
@@ -158,7 +161,7 @@ func HostPIDFromDS(ds *appsv1.DaemonSet) bool {
 	return ds.Spec.Template.Spec.HostPID
 }
 
-func CommandFromDS(ds *appsv1.DaemonSet, index int) []string {
+func CommandFromDS(ds *appsv1.DaemonSet, index ContainerIndex) []string {
 	return ds.Spec.Template.Spec.Containers[index].Command
 }
 
@@ -166,7 +169,7 @@ func AnnotationFromDS(ds *appsv1.DaemonSet) map[string]string {
 	return ds.Spec.Template.Annotations
 }
 
-func VolumeMountsFromDS(ds *appsv1.DaemonSet, index int) []corev1.VolumeMount {
+func VolumeMountsFromDS(ds *appsv1.DaemonSet, index ContainerIndex) []corev1.VolumeMount {
 	return ds.Spec.Template.Spec.Containers[index].VolumeMounts
 }
 


### PR DESCRIPTION
This PR 
* removes the RBAC role provided to both operator and kepler. 
* Condition now contains the namespace where redfish secret is expected to be present.
* reorgs the code to follow naming convention
* Uses `ContainerIndex` type to refer to a container in `spec.containers`
* Make Redfish test that failed with the follow error message more robust by waiting for controller to reconcile
```
--- FAIL: TestKeplerInternal_ReconciliationWithRedfish (0.09s)
panic: runtime error: index out of range [0] with length 0 [recovered]
        panic: runtime error: index out of range [0] with length 0

```
