### PR TITLE
feat: set availability to degraded when reconcile fails

### DIFF
--- a/pkg/api/v1alpha1/kepler_types.go
+++ b/pkg/api/v1alpha1/kepler_types.go
@@ -108,9 +108,10 @@ const (
 type ConditionStatus string
 
 const (
-	ConditionTrue    ConditionStatus = "True"
-	ConditionFalse   ConditionStatus = "False"
-	ConditionUnknown ConditionStatus = "Unknown"
+	ConditionTrue     ConditionStatus = "True"
+	ConditionFalse    ConditionStatus = "False"
+	ConditionUnknown  ConditionStatus = "Unknown"
+	ConditionDegraded ConditionStatus = "Degraded"
 )
 
 type Condition struct {

--- a/pkg/controllers/kepler.go
+++ b/pkg/controllers/kepler.go
@@ -220,18 +220,19 @@ func (r KeplerReconciler) setInvalidStatus(ctx context.Context, req ctrl.Request
 			return nil
 		}
 
+		now := metav1.Now()
 		invalidKepler.Status.Exporter.Conditions = []v1alpha1.Condition{{
 			Type:               v1alpha1.Reconciled,
 			Status:             v1alpha1.ConditionFalse,
 			ObservedGeneration: invalidKepler.Generation,
-			LastTransitionTime: metav1.Now(),
+			LastTransitionTime: now,
 			Reason:             v1alpha1.InvalidKeplerResource,
 			Message:            "Only a single instance of Kepler named kepler is reconciled",
 		}, {
 			Type:               v1alpha1.Available,
 			Status:             v1alpha1.ConditionUnknown,
 			ObservedGeneration: invalidKepler.Generation,
-			LastTransitionTime: metav1.Now(),
+			LastTransitionTime: now,
 			Reason:             v1alpha1.InvalidKeplerResource,
 			Message:            "This instance of Kepler is invalid",
 		}}


### PR DESCRIPTION
This commit adds a `Degraded` status. When reconcile fails, the status
of the `available` condition is set to `Degraded`. The commit also fixes
the LastTransitionTime to reflect actual last changed time that that
latest time when any of the condition was updated.
