### PR TITLE
POWERMON-251: ensure redfish config change restart kepler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 toolchain go1.21.7
 
 require (
+	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/go-logr/logr v1.4.1
 	github.com/openshift/api v0.0.0-20240212125214-04ea3891d9cb
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.71.2
@@ -20,7 +21,6 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect

--- a/pkg/components/exporter/exporter_test.go
+++ b/pkg/components/exporter/exporter_test.go
@@ -182,7 +182,8 @@ func TestDaemonSet(t *testing.T) {
 				},
 			},
 			annotation: map[string]string{
-				"kepler.system.sustainable.computing.io/redfish-secret-ref": "123",
+				"kepler.system.sustainable.computing.io/redfish-secret-ref":  "123",
+				"kepler.system.sustainable.computing.io/redfish-config-hash": "1337",
 			},
 			scenario: "redfish case",
 		},
@@ -202,23 +203,23 @@ func TestDaemonSet(t *testing.T) {
 			}
 			ds := NewDaemonSet(components.Full, &k)
 			if tc.addRedfish {
-				MountRedfishSecretToDaemonSet(ds, tc.redfishSecret)
+				MountRedfishSecretToDaemonSet(ds, tc.redfishSecret, 1337)
 			}
 
-			actual_hostPID := k8s.HostPIDFromDS(ds)
-			assert.Equal(t, actual_hostPID, tc.hostPID)
+			actualHostPID := k8s.HostPIDFromDS(ds)
+			assert.Equal(t, tc.hostPID, actualHostPID)
 
-			actual_exporterCommand := k8s.CommandFromDS(ds, KeplerContainerIndex)
-			assert.Equal(t, actual_exporterCommand, tc.exporterCommand)
+			actualExporterCommand := k8s.CommandFromDS(ds, KeplerContainerIndex)
+			assert.Equal(t, tc.exporterCommand, actualExporterCommand)
 
-			actual_volumeMounts := k8s.VolumeMountsFromDS(ds, KeplerContainerIndex)
-			assert.Equal(t, actual_volumeMounts, tc.volumeMounts)
+			actualVolumeMounts := k8s.VolumeMountsFromDS(ds, KeplerContainerIndex)
+			assert.Equal(t, tc.volumeMounts, actualVolumeMounts)
 
-			actual_Volumes := k8s.VolumesFromDS(ds)
-			assert.Equal(t, actual_Volumes, tc.volumes)
+			actualVolumes := k8s.VolumesFromDS(ds)
+			assert.Equal(t, tc.volumes, actualVolumes)
 
-			actual_Annotation := k8s.AnnotationFromDS(ds)
-			assert.Equal(t, actual_Annotation, tc.annotation)
+			actualAnnotation := k8s.AnnotationFromDS(ds)
+			assert.Equal(t, tc.annotation, actualAnnotation)
 		})
 	}
 }

--- a/pkg/controllers/kepler_internal.go
+++ b/pkg/controllers/kepler_internal.go
@@ -541,6 +541,7 @@ func exporterReconcilers(ki *v1alpha1.KeplerInternal, cluster k8s.Cluster) []rec
 		exporter.NewServiceMonitor(ki),
 		exporter.NewPrometheusRule(ki),
 	)...)
+
 	if ki.Spec.Exporter.Redfish == nil {
 		rs = append(rs, resourceReconcilers(updateResource,
 			exporter.NewDaemonSet(components.Full, ki),
@@ -548,12 +549,12 @@ func exporterReconcilers(ki *v1alpha1.KeplerInternal, cluster k8s.Cluster) []rec
 		)...)
 	} else {
 		rs = append(rs,
-			reconciler.KeplerDaemonSetReconciler{
-				Ki: *ki,
+			reconciler.KeplerReconciler{
+				Ki: ki,
 				Ds: exporter.NewDaemonSet(components.Full, ki),
 			},
 			reconciler.KeplerConfigMapReconciler{
-				Ki:  *ki,
+				Ki:  ki,
 				Cfm: exporter.NewConfigMap(components.Full, ki),
 			},
 		)


### PR DESCRIPTION
This commit modifies kepler reconciler to add the hash of redfish spec to pod annotations so that any change to the redfish spec will redeploy the pod.
This commit also fixes POWERMON-250 by removing the default redfish config added to kepler configmap.