### PR TITLE
update kepler-model-server version to 0.7.7

### DIFF
--- a/pkg/components/estimator/estimator.go
+++ b/pkg/components/estimator/estimator.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	// NOTE: update tests/images.yaml when changing this image
-	StableImage          = "quay.io/sustainable_computing_io/kepler_model_server:v0.6"
+	StableImage          = "quay.io/sustainable_computing_io/kepler_model_server:v0.7.7"
 	waitForSocketCommand = "until [ -e /tmp/estimator.sock ]; do sleep 1; done && %s"
 )
 

--- a/pkg/components/modelserver/modelserver.go
+++ b/pkg/components/modelserver/modelserver.go
@@ -38,7 +38,7 @@ const (
 
 const (
 	defaultModelServer = "http://%s.%s.svc.cluster.local:%d"
-	StableImage        = "quay.io/sustainable_computing_io/kepler_model_server:v0.6"
+	StableImage        = "quay.io/sustainable_computing_io/kepler_model_server:v0.7.7"
 )
 
 var (

--- a/tests/images.yaml
+++ b/tests/images.yaml
@@ -1,3 +1,3 @@
 images:
 - component: 'model-server'
-  image: 'quay.io/sustainable_computing_io/kepler_model_server:v0.6'
+  image: 'quay.io/sustainable_computing_io/kepler_model_server:v0.7.7'


### PR DESCRIPTION
Update stable image and test image for Kepler Model Server

Please refer to the release note: 
https://github.com/sustainable-computing-io/kepler-model-server/releases/tag/v0.7.7-release

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>