### PR TITLE
fix(OLM): ensure kepler can be created through Console

### DIFF
--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -19,7 +19,8 @@ metadata:
             "exporter": {
               "deployment": {
                 "port": 9103
-              }
+              },
+              "redfish": null
             }
           }
         }

--- a/config/samples/kepler.system_v1alpha1_kepler.yaml
+++ b/config/samples/kepler.system_v1alpha1_kepler.yaml
@@ -10,4 +10,5 @@ spec:
   exporter:
     deployment:
       port: 9103
+    redfish: null
 

--- a/pkg/api/v1alpha1/kepler_types.go
+++ b/pkg/api/v1alpha1/kepler_types.go
@@ -61,7 +61,10 @@ type RedfishSpec struct {
 
 type ExporterSpec struct {
 	Deployment ExporterDeploymentSpec `json:"deployment,omitempty"`
-	Redfish    *RedfishSpec           `json:"redfish,omitempty"`
+
+	// +optional
+	// +kubebuilder:validation:optional
+	Redfish *RedfishSpec `json:"redfish,omitempty"`
 }
 
 // KeplerSpec defines the desired state of Kepler


### PR DESCRIPTION
Previously, when creating Kepler instance through OpenShift Console / UI, the redfish spec which is optional also had its fields initialized as well.  Notably `redfish.secrefRef` was initialized to "". This prevented creation of `kepler` instance since the `secretRef` is a required field.

This commit fixes the issue by marking `redfish` as `optional` and updating the default sample to reflect that.