### PR TITLE
feat(dashboard): show platform power source

### DIFF
--- a/pkg/components/exporter/assets/dashboards/power-monitoring-overview.json
+++ b/pkg/components/exporter/assets/dashboards/power-monitoring-overview.json
@@ -120,7 +120,7 @@
           "linkTargetBlank": false,
           "pattern": "platform_power_source",
           "thresholds": [],
-          "type": "hidden",
+          "type": "number",
           "unit": "short"
         },
         {
@@ -436,7 +436,7 @@
           "linkTargetBlank": false,
           "pattern": "platform_power_source",
           "thresholds": [],
-          "type": "hidden",
+          "type": "number",
           "unit": "short"
         },
         {


### PR DESCRIPTION
This reverts commit 21d829821a012e6aa9f75845cf342f5e13b28beb.

<img width="790" alt="image" src="https://github.com/sustainable-computing-io/kepler-operator/assets/3005132/f7dc2143-5858-4b28-98e5-316595db2d8e">
