### PR TITLE
chore: bump up Kepler to 0.7.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ GOARCH := $(shell go env GOARCH)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= $(shell cat VERSION)
 
-KEPLER_VERSION ?=release-0.7.10
+KEPLER_VERSION ?=release-0.7.11
 
 # IMG_BASE and KEPLER_IMG_BASE are set to distinguish between Operator-specific images and Kepler-Specific images.
 # IMG_BASE is used for building and pushing operator related images.

--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.13.0
-    createdAt: "2024-05-22T07:06:13Z"
+    createdAt: "2024-07-11T07:04:57Z"
     description: 'Deploys and Manages Kepler on Kubernetes '
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/internal-objects: |-
@@ -267,7 +267,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_KEPLER
-                  value: quay.io/sustainable_computing_io/kepler:release-0.7.10
+                  value: quay.io/sustainable_computing_io/kepler:release-0.7.11
                 image: quay.io/sustainable_computing_io/kepler-operator:0.13.0
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
@@ -377,7 +377,7 @@ spec:
     name: Kepler Operator Contributors
     url: https://sustainable-computing.io/
   relatedImages:
-  - image: quay.io/sustainable_computing_io/kepler:release-0.7.10
+  - image: quay.io/sustainable_computing_io/kepler:release-0.7.11
     name: kepler
   replaces: kepler-operator.v0.12.0
   version: 0.13.0

--- a/tests/e2e/kepler_internal_test.go
+++ b/tests/e2e/kepler_internal_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	keplerImage = `quay.io/sustainable_computing_io/kepler:release-0.7.10`
+	keplerImage = `quay.io/sustainable_computing_io/kepler:release-0.7.11`
 )
 
 func TestKeplerInternal_Reconciliation(t *testing.T) {


### PR DESCRIPTION
This commit bumps up Kepler version to 0.7.11