### PR TITLE
POWERMON-306: fix wrong Prometheus rule reference for OTHER Power Consumption

### DIFF
--- a/hack/dashboard/assets/kepler/dashboard.json
+++ b/hack/dashboard/assets/kepler/dashboard.json
@@ -1100,7 +1100,7 @@
         {
           "datasource": "prometheus",
           "editorMode": "code",
-          "expr": "sum by (pod_name) (kepler:kepler:other_joules_watts:1m:by_ns_pod{container_namespace=~\"$namespace\", pod_name=~\"$pod\"})",
+          "expr": "sum by (pod_name) (kepler:kepler:container_other_watts:1m:by_ns_pod{container_namespace=~\"$namespace\", pod_name=~\"$pod\"})",
           "hide": false,
           "interval": "5m",
           "legendFormat": "{{pod_name}}",

--- a/pkg/components/exporter/assets/dashboards/power-monitoring-by-ns.json
+++ b/pkg/components/exporter/assets/dashboards/power-monitoring-by-ns.json
@@ -615,7 +615,7 @@
         {
           "datasource": "prometheus",
           "editorMode": "code",
-          "expr": "sum by (pod_name) (kepler:kepler:other_joules_watts:1m:by_ns_pod{container_namespace=~\"$namespace\", pod_name=~\"$pod\"})",
+          "expr": "sum by (pod_name) (kepler:kepler:container_other_watts:1m:by_ns_pod{container_namespace=~\"$namespace\", pod_name=~\"$pod\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod_name}} }}",


### PR DESCRIPTION
This commit fixes the issue where the wrong Prometheus rule was referenced for displaying `OTHER Power Consumption(W) by Pods` in the dashboard