### PR TITLE
chore: Bump up model-server to v0.7.11

### DIFF
--- a/pkg/components/estimator/estimator.go
+++ b/pkg/components/estimator/estimator.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	// NOTE: update tests/images.yaml when changing this image
-	StableImage          = "quay.io/sustainable_computing_io/kepler_model_server:v0.7.7"
+	StableImage          = "quay.io/sustainable_computing_io/kepler_model_server:v0.7.11"
 	waitForSocketCommand = "until [ -e /tmp/estimator.sock ]; do sleep 1; done && %s"
 )
 
@@ -76,7 +76,7 @@ func Container(image string) corev1.Container {
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Name:            "estimator",
 		VolumeMounts:    mounts,
-		Command:         []string{"python3.8"},
+		Command:         []string{"python3.10"},
 		Args:            []string{"-u", "src/estimate/estimator.py"},
 	}
 }

--- a/pkg/components/modelserver/modelserver.go
+++ b/pkg/components/modelserver/modelserver.go
@@ -38,7 +38,7 @@ const (
 
 const (
 	defaultModelServer = "http://%s.%s.svc.cluster.local:%d"
-	StableImage        = "quay.io/sustainable_computing_io/kepler_model_server:v0.7.7"
+	StableImage        = "quay.io/sustainable_computing_io/kepler_model_server:v0.7.11"
 )
 
 var (
@@ -86,7 +86,7 @@ func NewDeployment(deployName string, ms *v1alpha1.InternalModelServerSpec, name
 			Name:          "http",
 		}},
 		VolumeMounts: mounts,
-		Command:      []string{"python3.8"},
+		Command:      []string{"python3.10"},
 		Args:         []string{"-u", "src/server/model_server.py"},
 	}}
 

--- a/tests/images.yaml
+++ b/tests/images.yaml
@@ -1,3 +1,3 @@
 images:
 - component: 'model-server'
-  image: 'quay.io/sustainable_computing_io/kepler_model_server:v0.7.7'
+  image: 'quay.io/sustainable_computing_io/kepler_model_server:v0.7.11'


### PR DESCRIPTION
This commit bumps up model-server image to `v0.7.11`

Address #412 