### PR TITLE
chore: Bump up model-server to v0.7.11-2

### DIFF
--- a/pkg/components/estimator/estimator.go
+++ b/pkg/components/estimator/estimator.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	// NOTE: update tests/images.yaml when changing this image
-	StableImage          = "quay.io/sustainable_computing_io/kepler_model_server:v0.7.11"
+	StableImage          = "quay.io/sustainable_computing_io/kepler_model_server:v0.7.11-2"
 	waitForSocketCommand = "until [ -e /tmp/estimator.sock ]; do sleep 1; done && %s"
 )
 
@@ -76,8 +76,8 @@ func Container(image string) corev1.Container {
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Name:            "estimator",
 		VolumeMounts:    mounts,
-		Command:         []string{"python3.10"},
-		Args:            []string{"-u", "src/estimate/estimator.py"},
+		Command:         []string{"estimator"},
+		Args:            []string{"-l", "info"},
 	}
 }
 

--- a/pkg/components/estimator/estimator.go
+++ b/pkg/components/estimator/estimator.go
@@ -33,7 +33,7 @@ const (
 )
 
 var (
-	shellCommand = []string{"/bin/sh", "-c"}
+	shellCommand = []string{"/usr/bin/bash", "-c"}
 )
 
 // NeedsEstimatorSidecar returns true if any of estimator config has sidecar enabled

--- a/pkg/components/estimator/estimator_test.go
+++ b/pkg/components/estimator/estimator_test.go
@@ -109,7 +109,7 @@ func TestModifiedContainer(t *testing.T) {
 	exporterContainer := &corev1.Container{
 		Command: []string{"kepler", "-v=1"},
 	}
-	expectedCommand := []string{"/bin/sh", "-c"}
+	expectedCommand := []string{"/usr/bin/bash", "-c"}
 	expectedArgs := []string{"until [ -e /tmp/estimator.sock ]; do sleep 1; done && kepler -v=1"}
 	expectedVolumeMounts := []string{"cfm", "mnt", "tmp"}
 	keplerVolumes := []corev1.Volume{k8s.VolumeFromEmptyDir("kepler-volume")}

--- a/pkg/components/modelserver/modelserver.go
+++ b/pkg/components/modelserver/modelserver.go
@@ -38,7 +38,7 @@ const (
 
 const (
 	defaultModelServer = "http://%s.%s.svc.cluster.local:%d"
-	StableImage        = "quay.io/sustainable_computing_io/kepler_model_server:v0.7.11"
+	StableImage        = "quay.io/sustainable_computing_io/kepler_model_server:v0.7.11-2"
 )
 
 var (
@@ -86,8 +86,8 @@ func NewDeployment(deployName string, ms *v1alpha1.InternalModelServerSpec, name
 			Name:          "http",
 		}},
 		VolumeMounts: mounts,
-		Command:      []string{"python3.10"},
-		Args:         []string{"-u", "src/server/model_server.py"},
+		Command:      []string{"model-server"},
+		Args:         []string{"-l", "info"},
 	}}
 
 	return &appsv1.Deployment{

--- a/pkg/components/modelserver/modelserver.go
+++ b/pkg/components/modelserver/modelserver.go
@@ -18,6 +18,7 @@ package modelserver
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/sustainable.computing.io/kepler-operator/api/v1alpha1"
 	"github.com/sustainable.computing.io/kepler-operator/pkg/components"
@@ -37,8 +38,9 @@ const (
 )
 
 const (
-	defaultModelServer = "http://%s.%s.svc.cluster.local:%d"
-	StableImage        = "quay.io/sustainable_computing_io/kepler_model_server:v0.7.11-2"
+	defaultModelServer        = "http://%s.%s.svc.cluster.local:%d"
+	StableImage               = "quay.io/sustainable_computing_io/kepler_model_server:v0.7.11-2"
+	waitForModelServerCommand = "until [[ \"$(curl -s -o /dev/null -w %%{http_code} %s/best-models)\" -eq 200 ]]; do sleep 1; done"
 )
 
 var (
@@ -51,6 +53,10 @@ var (
 	podSelector = labels.Merge(k8s.StringMap{
 		"app.kubernetes.io/name": "model-server",
 	})
+)
+
+var (
+	shellCommand = []string{"/usr/bin/bash", "-c"}
 )
 
 func NewDeployment(deployName string, ms *v1alpha1.InternalModelServerSpec, namespace string) *appsv1.Deployment {
@@ -217,4 +223,21 @@ func serverUrl(deployName, deployNamespace string, ms v1alpha1.InternalModelServ
 	port := ms.Port
 	serviceName := deployName + ServiceSuffix
 	return fmt.Sprintf(defaultModelServer, serviceName, deployNamespace, port)
+}
+
+func formatModelServerCommand(deployName, deployNamespace string, ms v1alpha1.InternalModelServerSpec) string {
+	return fmt.Sprintf(waitForModelServerCommand, serverUrl(deployName, deployNamespace, ms))
+}
+
+func addModelServerWaitCmd(exporterContainer *corev1.Container, deployName, deployNamespace string, ms v1alpha1.InternalModelServerSpec) *corev1.Container {
+	cmd := exporterContainer.Command
+	exporterContainer.Command = shellCommand
+	exporterContainer.Args = []string{fmt.Sprintf("%s && %s", formatModelServerCommand(deployName, deployNamespace, ms), strings.Join(cmd, " "))}
+	return exporterContainer
+
+}
+
+func AddModelServerDependency(exporterContainer *corev1.Container, deployName, deployNamespace string, ms *v1alpha1.InternalModelServerSpec) *corev1.Container {
+	exporterContainer = addModelServerWaitCmd(exporterContainer, deployName, deployNamespace, *ms)
+	return exporterContainer
 }

--- a/tests/images.yaml
+++ b/tests/images.yaml
@@ -1,3 +1,3 @@
 images:
 - component: 'model-server'
-  image: 'quay.io/sustainable_computing_io/kepler_model_server:v0.7.11'
+  image: 'quay.io/sustainable_computing_io/kepler_model_server:v0.7.11-2'


### PR DESCRIPTION
This commit bumps up model-server to `v0.7.11-2`

Addresses: #420 