### PR TITLE
fix(dashboard): remove extra braces from legend

### DIFF
--- a/pkg/components/exporter/assets/dashboards/power-monitoring-by-ns.json
+++ b/pkg/components/exporter/assets/dashboards/power-monitoring-by-ns.json
@@ -618,7 +618,7 @@
           "expr": "sum by (pod_name) (kepler:kepler:container_other_watts:1m:by_ns_pod{container_namespace=~\"$namespace\", pod_name=~\"$pod\"})",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{pod_name}} }}",
+          "legendFormat": "{{pod_name}}",
           "range": true,
           "refId": "A"
         }


### PR DESCRIPTION
This commit removes the extra braces from the legend of the Power Monitoring by Namespace dashboard for the `OTHER Power Consumption by Pods` panel