### PR TITLE
fix(modelserver): add volume mount for resource directory

### DIFF
--- a/pkg/components/modelserver/modelserver.go
+++ b/pkg/components/modelserver/modelserver.go
@@ -71,6 +71,7 @@ func NewDeployment(deployName string, ms *v1alpha1.InternalModelServerSpec, name
 	volumes := []corev1.Volume{
 		storage,
 		k8s.VolumeFromConfigMap("cfm", configMapName),
+		k8s.VolumeFromEmptyDir("resource"),
 	}
 
 	mounts := []corev1.VolumeMount{{
@@ -80,6 +81,9 @@ func NewDeployment(deployName string, ms *v1alpha1.InternalModelServerSpec, name
 	}, {
 		Name:      "mnt",
 		MountPath: "/mnt",
+	}, {
+		Name:      "resource",
+		MountPath: "/usr/local/lib/python3.10/site-packages/resource",
 	}}
 
 	port := ms.Port


### PR DESCRIPTION
This commit addresses a permission issue where the model server, running as non-root user fails to create the resource directory under `/usr/local/lib/python3.10/site-packages/` A new volume and mount is added specifically for this ensuring necessary permissions are set