### PR TITLE
chore(ci): remove space reclamation steps for GH runners

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -134,7 +134,7 @@ jobs:
       KUBECONFIG: /tmp/.kube/config
       KIND_WORKER_NODES: 2
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v3
         with:
@@ -223,15 +223,6 @@ jobs:
 
       - uses: ./.github/compute-version
         id: version
-
-      - name: reclaim space before running tests
-        run: |
-          sudo apt-get clean
-          sudo rm -rf /var/lib/apt/lists/*
-          sudo rm -rf /tmp/*
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /opt/hostedtoolcache/Python
-          df -kh
 
       - name: Run e2e tests
         run: |


### PR DESCRIPTION
This commit removes the steps previously used to reclaim space on GH runners. Since we have moved to self-hosted runners with more resources available, these steps are no longer necessary

Addresses: #429 