### PR TITLE
fix_deploy_grafana_script

### DIFF
--- a/hack/dashboard/openshift/deploy-grafana.sh
+++ b/hack/dashboard/openshift/deploy-grafana.sh
@@ -10,8 +10,8 @@ declare -r MON_NS=openshift-monitoring
 declare -r UWM_NS=openshift-user-workload-monitoring
 declare -r CMO_CM=cluster-monitoring-config
 declare -r BACKUP_CMO_CFG="$BACKUP_DIR/cmo-cm.yaml"
-declare -r UWM_URL="https://docs.openshift.com/container-platform/latest/monitoring/enabling-monitoring-for-user-defined-projects.html"
-declare -r UWM_CONFIG_URL="https://docs.openshift.com/container-platform/latest/monitoring/configuring-the-monitoring-stack.html#configuring-the-monitoring-stack_configuring-the-monitoring-stack"
+declare -r UWM_URL="https://docs.openshift.com/container-platform/latest/observability/monitoring/enabling-monitoring-for-user-defined-projects.html"
+declare -r UWM_CONFIG_URL="https://docs.openshift.com/container-platform/latest/observability/monitoring/configuring-the-monitoring-stack.html#configuring-the-monitoring-stack_configuring-the-monitoring-stack"
 
 declare -r GRAFANA_NS=kepler-grafana
 declare -r GRAFANA_SA=grafana
@@ -45,7 +45,7 @@ validate_cluster() {
 		fail "No oc command found in PATH"
 		info "Please install oc"
 		cat <<-EOF
-			curl -sNL https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.13.0/openshift-client-linux.tar.gz |
+			curl -sNL https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.16.0/openshift-client-linux.tar.gz |
 			  tar -xzf - -C <install/path>
 		EOF
 		# NOTE: do not proceed without oc installed
@@ -236,9 +236,9 @@ setup_grafana() {
 		oc get grafana,grafanadatasource
 
 	wait_until 10 10 "Grafana CRDs to be Established" \
-		oc wait --for=condition=Established crd grafanas.integreatly.org
+		oc wait --for=condition=Established crd grafanas.grafana.integreatly.org
 	wait_until 10 10 "Grafana Datasource CRDs to be Established" \
-		oc wait --for=condition=Established crd grafanadatasources.integreatly.org
+		oc wait --for=condition=Established crd grafanadatasources.grafana.integreatly.org
 	ok "grafana crds created\n"
 
 	info "Creating a grafana instance"
@@ -290,14 +290,14 @@ setup_grafana_dashboard() {
 
 	# NOTE: route name is dependent on the grafana instance
 	wait_until 20 2 "Grafana dashboard" \
-		oc_get_grafana_ns route grafana-route
+		oc_get_grafana_ns route kepler-grafana-route
 
 	ok "created grafana dashboard\n"
 }
 
 grafana_login_url() {
 	local grafana_url=""
-	echo "https://$(oc_get_grafana_ns route grafana-route -o jsonpath='{.spec.host}')/login"
+	echo "https://$(oc_get_grafana_ns route kepler-grafana-route -o jsonpath='{.spec.host}')/login"
 
 }
 

--- a/hack/dashboard/openshift/grafana-config/01-grafana-instance.yaml
+++ b/hack/dashboard/openshift/grafana-config/01-grafana-instance.yaml
@@ -1,18 +1,26 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana
 metadata:
   name: kepler-grafana
+  labels:
+    dashboards: kepler-grafana
 spec:
   # TODO: this hard-coded image version is necessary until the currently available version
   # of grafana operator from OperatorHub (v4.7.1) pulls in a later version of grafana
-  baseImage: 'docker.io/grafana/grafana:8.5.5'
+  baseImage: 'docker.io/grafana/grafana:11.3.0'
+  route:
+    spec:
+      to:
+        kind: Service
+        name: kepler-grafana-service
+        weight: 100
   ingress:
     enabled: true
   config:
     auth:
-      disable_signout_menu: true
+      disable_signout_menu: "true"
     auth.anonymous:
-      enabled: true
+      enabled: "true"
     log:
       level: warn
       mode: console

--- a/hack/dashboard/openshift/grafana-config/03-grafana-datasource-UPDATETHIS.yaml
+++ b/hack/dashboard/openshift/grafana-config/03-grafana-datasource-UPDATETHIS.yaml
@@ -2,13 +2,13 @@
 #  oc adm policy add-cluster-role-to-user cluster-monitoring-view -z grafana-serviceaccount
 # 2. Get bearer token for `grafana-serviceaccount`. Update manifest.
 #  oc serviceaccounts get-token grafana-serviceaccount -n kepler
-apiVersion: integreatly.org/v1alpha1
-kind: GrafanaDataSource
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
 metadata:
   name: prometheus-grafanadatasource
 spec:
-  datasources:
-    - access: proxy
+  datasource:
+      access: proxy
       editable: true
       isDefault: true
       jsonData:
@@ -22,3 +22,7 @@ spec:
       type: prometheus
       url: 'https://thanos-querier.openshift-monitoring.svc.cluster.local:9091'
   name: prometheus-grafanadatasource.yaml
+  # The spec.instanceSelectors field is used to tell the operator which Grafana instance the resource applies to.
+  instanceSelector:
+    matchLabels:
+      dashboards: kepler-grafana

--- a/hack/dashboard/openshift/grafana-config/04-kepler-dashboard.yaml
+++ b/hack/dashboard/openshift/grafana-config/04-kepler-dashboard.yaml
@@ -1,10 +1,13 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: kepler-dashboard
   labels:
     app: grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: kepler-grafana
   configMapRef:
     name: kepler-dashboard-cm
     key: dashboard.json

--- a/hack/dashboard/openshift/grafana-config/05-prometheus-dashboard.yaml
+++ b/hack/dashboard/openshift/grafana-config/05-prometheus-dashboard.yaml
@@ -1,10 +1,13 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: prometheus-dashboard
   labels:
     app: grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: kepler-grafana
   configMapRef:
     name: prometheus-dashboard-cm
     key: dashboard.json

--- a/hack/dashboard/openshift/grafana-deploy/01-grafana-operator.yaml
+++ b/hack/dashboard/openshift/grafana-deploy/01-grafana-operator.yaml
@@ -13,9 +13,10 @@ kind: Subscription
 metadata:
   name: grafana-operator
 spec:
-  channel: v4
+  channel: v5
   installPlanApproval: Automatic
   name: grafana-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: grafana-operator.v4.10.1
+  startingCSV: grafana-operator.v5.15.1
+  

--- a/hack/dashboard/openshift/uwm/00-openshift-monitoring-user-projects.yaml
+++ b/hack/dashboard/openshift/uwm/00-openshift-monitoring-user-projects.yaml
@@ -1,5 +1,5 @@
 ---
-# https://docs.openshift.com/container-platform/4.10/monitoring/enabling-monitoring-for-user-defined-projects.html
+# https://docs.openshift.com/container-platform/latest/observability/monitoring/enabling-monitoring-for-user-defined-projects.html
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
fix deploy-grafana.sh script to make it compatible with OCP 4.16  version. 
Following updates were made:

1. corrected document links
2. deploy-grafana.sh script updated to carry latest oc client version
3. added labels in grafana resource and updated grafana docker image to latest version
4. apiVersion updated for Grafana,GrafanaDatasource,GrafanaDashboard resource definitions
5. grafana-operator channel updated to latest version
6. other cosmetic changes