### PR TITLE
docs: update deprecated UWM links

### DIFF
--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.15.0
-    createdAt: "2025-02-14T06:23:56Z"
+    createdAt: "2025-02-19T04:59:32Z"
     description: 'Deploys and Manages Kepler on Kubernetes '
     operators.operatorframework.io/builder: operator-sdk-v1.39.1
     operators.operatorframework.io/internal-objects: |-
@@ -75,7 +75,7 @@ spec:
 
     ### NOTE
     To view the metrics exposed by kepler, ensure that
-    [User Project Monitoring](https://docs.openshift.com/container-platform/latest/monitoring/enabling-monitoring-for-user-defined-projects.html)
+    [User Project Monitoring](https://docs.redhat.com/documentation/openshift_container_platform/latest/html/monitoring/configuring-user-workload-monitoring)
     is enabled in your cluster.
 
     ### Documentation

--- a/config/manifests/bases/kepler-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kepler-operator.clusterserviceversion.yaml
@@ -52,7 +52,7 @@ spec:
 
     ### NOTE
     To view the metrics exposed by kepler, ensure that
-    [User Project Monitoring](https://docs.openshift.com/container-platform/latest/monitoring/enabling-monitoring-for-user-defined-projects.html)
+    [User Project Monitoring](https://docs.redhat.com/documentation/openshift_container_platform/latest/html/monitoring/configuring-user-workload-monitoring)
     is enabled in your cluster.
 
     ### Documentation

--- a/hack/dashboard/openshift/deploy-grafana.sh
+++ b/hack/dashboard/openshift/deploy-grafana.sh
@@ -10,8 +10,8 @@ declare -r MON_NS=openshift-monitoring
 declare -r UWM_NS=openshift-user-workload-monitoring
 declare -r CMO_CM=cluster-monitoring-config
 declare -r BACKUP_CMO_CFG="$BACKUP_DIR/cmo-cm.yaml"
-declare -r UWM_URL="https://docs.openshift.com/container-platform/latest/observability/monitoring/enabling-monitoring-for-user-defined-projects.html"
-declare -r UWM_CONFIG_URL="https://docs.openshift.com/container-platform/latest/observability/monitoring/configuring-the-monitoring-stack.html#configuring-the-monitoring-stack_configuring-the-monitoring-stack"
+declare -r UWM_URL="https://docs.redhat.com/documentation/openshift_container_platform/latest/html/monitoring/configuring-user-workload-monitoring"
+declare -r UWM_CONFIG_URL="https://docs.redhat.com/documentation/openshift_container_platform/latest/html/monitoring/configuring-user-workload-monitoring#preparing-to-configure-the-monitoring-stack-uwm"
 
 declare -r GRAFANA_NS=kepler-grafana
 declare -r GRAFANA_SA=grafana

--- a/hack/dashboard/openshift/uwm/00-openshift-monitoring-user-projects.yaml
+++ b/hack/dashboard/openshift/uwm/00-openshift-monitoring-user-projects.yaml
@@ -1,5 +1,5 @@
 ---
-# https://docs.openshift.com/container-platform/latest/observability/monitoring/enabling-monitoring-for-user-defined-projects.html
+# https://docs.redhat.com/documentation/openshift_container_platform/latest/html/monitoring/configuring-user-workload-monitoring
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
This PR updates the invalid links to the user workload monitoring to the new ones. The new links are moved from docs.openshift.com to docs.redhat.com as docs.openshift.com will be decommissioned soon.