### PR TITLE
chore(tests): use wait.PollUntilContextTimeout

### DIFF
--- a/pkg/utils/test/framework.go
+++ b/pkg/utils/test/framework.go
@@ -186,9 +186,9 @@ func (f Framework) DeleteKepler(name string) {
 		f.T.Errorf("failed to delete kepler:%s :%v", name, err)
 	}
 
-	f.WaitUntil(fmt.Sprintf("kepler %s is deleted", name), func() (bool, error) {
+	f.WaitUntil(fmt.Sprintf("kepler %s is deleted", name), func(ctx context.Context) (bool, error) {
 		k := v1alpha1.Kepler{}
-		err := f.client.Get(context.TODO(), client.ObjectKey{Name: name}, &k)
+		err := f.client.Get(ctx, client.ObjectKey{Name: name}, &k)
 		return errors.IsNotFound(err), nil
 	})
 }
@@ -246,9 +246,9 @@ func (f Framework) DeleteInternal(name string, fns ...AssertOptionFn) {
 		f.T.Errorf("failed to delete kepler-internal:%s :%v", name, err)
 	}
 
-	f.WaitUntil(fmt.Sprintf("kepler-internal %s is deleted", name), func() (bool, error) {
+	f.WaitUntil(fmt.Sprintf("kepler-internal %s is deleted", name), func(ctx context.Context) (bool, error) {
 		k := v1alpha1.KeplerInternal{}
-		err := f.client.Get(context.TODO(), client.ObjectKey{Name: name}, &k)
+		err := f.client.Get(ctx, client.ObjectKey{Name: name}, &k)
 		return errors.IsNotFound(err), nil
 	}, fns...)
 }
@@ -257,8 +257,8 @@ func (f Framework) WaitUntilInternalCondition(name string, t v1alpha1.ConditionT
 	f.T.Helper()
 	k := v1alpha1.KeplerInternal{}
 	f.WaitUntil(fmt.Sprintf("kepler-internal %s is %s", name, t),
-		func() (bool, error) {
-			err := f.client.Get(context.TODO(), client.ObjectKey{Name: name}, &k)
+		func(ctx context.Context) (bool, error) {
+			err := f.client.Get(ctx, client.ObjectKey{Name: name}, &k)
 			if errors.IsNotFound(err) {
 				return true, fmt.Errorf("kepler-internal %s is not found", name)
 			}
@@ -273,8 +273,8 @@ func (f Framework) AssertEstimatorStatus(name string, fns ...AssertOptionFn) *v1
 	f.T.Helper()
 	k := v1alpha1.KeplerInternal{}
 
-	f.WaitUntil(fmt.Sprintf("estimator for %s has expected status", name), func() (bool, error) {
-		err := f.client.Get(context.TODO(), client.ObjectKey{Name: name}, &k)
+	f.WaitUntil(fmt.Sprintf("estimator for %s has expected status", name), func(ctx context.Context) (bool, error) {
+		err := f.client.Get(ctx, client.ObjectKey{Name: name}, &k)
 		if errors.IsNotFound(err) {
 			return true, fmt.Errorf("kepler-internal %s is not found", name)
 		}
@@ -296,8 +296,8 @@ func (f Framework) AssertModelServerStatus(name string, fns ...AssertOptionFn) *
 	f.T.Helper()
 	k := v1alpha1.KeplerInternal{}
 
-	f.WaitUntil(fmt.Sprintf("model-server for %s has expected status", name), func() (bool, error) {
-		err := f.client.Get(context.TODO(), client.ObjectKey{Name: name}, &k)
+	f.WaitUntil(fmt.Sprintf("model-server for %s has expected status", name), func(ctx context.Context) (bool, error) {
+		err := f.client.Get(ctx, client.ObjectKey{Name: name}, &k)
 		if errors.IsNotFound(err) {
 			return true, fmt.Errorf("kepler-internal %s is not found", name)
 		}
@@ -319,8 +319,8 @@ func (f Framework) WaitUntilKeplerCondition(name string, t v1alpha1.ConditionTyp
 	f.T.Helper()
 	k := v1alpha1.Kepler{}
 	f.WaitUntil(fmt.Sprintf("kepler %s is %s", name, t),
-		func() (bool, error) {
-			err := f.client.Get(context.TODO(), client.ObjectKey{Name: name}, &k)
+		func(ctx context.Context) (bool, error) {
+			err := f.client.Get(ctx, client.ObjectKey{Name: name}, &k)
 			if errors.IsNotFound(err) {
 				return true, fmt.Errorf("kepler %s is not found", name)
 			}

--- a/tests/e2e/kepler_internal_test.go
+++ b/tests/e2e/kepler_internal_test.go
@@ -46,7 +46,7 @@ func TestKeplerInternal_Reconciliation(t *testing.T) {
 	testNs := controller.KeplerDeploymentNS
 
 	// pre-condition
-	f.AssertNoResourceExists(name, "", &v1alpha1.KeplerInternal{}, test.NoWait())
+	f.AssertNoResourceExists(name, "", &v1alpha1.KeplerInternal{})
 
 	// when
 	b := test.InternalBuilder{}
@@ -79,7 +79,7 @@ func TestKeplerInternal_ReconciliationWithRedfish(t *testing.T) {
 	testNs := controller.KeplerDeploymentNS
 
 	// pre-condition
-	f.AssertNoResourceExists(name, "", &v1alpha1.KeplerInternal{}, test.NoWait())
+	f.AssertNoResourceExists(name, "", &v1alpha1.KeplerInternal{})
 
 	// when
 	b := test.InternalBuilder{}
@@ -141,8 +141,8 @@ func TestKeplerInternal_ReconciliationWithRedfish(t *testing.T) {
 
 	// wait for DaemonSet to restart
 	ds = appsv1.DaemonSet{}
-	f.WaitUntil("Daemonset to restart", func() (bool, error) {
-		err := f.Client().Get(context.TODO(),
+	f.WaitUntil("Daemonset to restart", func(ctx context.Context) (bool, error) {
+		err := f.Client().Get(ctx,
 			client.ObjectKey{Namespace: controller.KeplerDeploymentNS, Name: ki.Name}, &ds)
 		if errors.IsNotFound(err) {
 			return false, nil
@@ -160,14 +160,14 @@ func TestKeplerInternal_WithEstimator(t *testing.T) {
 	f := test.NewFramework(t)
 	name := "e2e-ki-with-estimator"
 	// Ensure Kepler is not deployed (by any chance)
-	f.AssertNoResourceExists(name, "", &v1alpha1.KeplerInternal{}, test.NoWait())
+	f.AssertNoResourceExists(name, "", &v1alpha1.KeplerInternal{})
 
 	// test namespace must be the deployment namespace for controller
 	// to watch the deployments / daemonsets etc
 	testNs := controller.KeplerDeploymentNS
 
 	// pre-condition
-	f.AssertNoResourceExists(name, "", &v1alpha1.KeplerInternal{}, test.NoWait())
+	f.AssertNoResourceExists(name, "", &v1alpha1.KeplerInternal{})
 	// when
 	b := test.InternalBuilder{}
 	ki := f.CreateInternal(name,
@@ -193,14 +193,14 @@ func TestKeplerInternal_WithModelServer(t *testing.T) {
 	f := test.NewFramework(t)
 	name := "e2e-ki-with-modelserver"
 	// Ensure Kepler is not deployed (by any chance)
-	f.AssertNoResourceExists(name, "", &v1alpha1.KeplerInternal{}, test.NoWait())
+	f.AssertNoResourceExists(name, "", &v1alpha1.KeplerInternal{})
 
 	// test namespace must be the deployment namespace for controller
 	// to watch the deployments / daemonsets etc
 	testNs := controller.KeplerDeploymentNS
 
 	// pre-condition
-	f.AssertNoResourceExists(name, "", &v1alpha1.KeplerInternal{}, test.NoWait())
+	f.AssertNoResourceExists(name, "", &v1alpha1.KeplerInternal{})
 	// when
 	b := test.InternalBuilder{}
 	ki := f.CreateInternal(name,
@@ -231,14 +231,14 @@ func TestKeplerInternal_WithEstimatorAndModelServer(t *testing.T) {
 	f := test.NewFramework(t)
 	name := "e2e-ki-est-mserver"
 	// Ensure Kepler is not deployed (by any chance)
-	f.AssertNoResourceExists(name, "", &v1alpha1.KeplerInternal{}, test.NoWait())
+	f.AssertNoResourceExists(name, "", &v1alpha1.KeplerInternal{})
 
 	// test namespace must be the deployment namespace for controller
 	// to watch the deployments / daemonsets etc
 	testNs := controller.KeplerDeploymentNS
 
 	// pre-condition
-	f.AssertNoResourceExists(name, "", &v1alpha1.KeplerInternal{}, test.NoWait())
+	f.AssertNoResourceExists(name, "", &v1alpha1.KeplerInternal{})
 	// when
 	b := test.InternalBuilder{}
 	ki := f.CreateInternal(name,

--- a/tests/e2e/kepler_test.go
+++ b/tests/e2e/kepler_test.go
@@ -42,7 +42,7 @@ func TestKepler_Reconciliation(t *testing.T) {
 	f := test.NewFramework(t)
 
 	// pre-condition
-	f.AssertNoResourceExists("kepler", "", &v1alpha1.Kepler{}, test.NoWait())
+	f.AssertNoResourceExists("kepler", "", &v1alpha1.Kepler{})
 
 	// when
 	k := f.CreateKepler("kepler")
@@ -72,7 +72,7 @@ func TestBadKepler_Reconciliation(t *testing.T) {
 	f := test.NewFramework(t)
 	// Ensure Kepler is not deployed (by any chance)
 	f.AssertNoResourceExists("kepler", "", &v1alpha1.Kepler{}, test.Timeout(10*time.Second))
-	f.AssertNoResourceExists("invalid-name", "", &v1alpha1.Kepler{}, test.NoWait())
+	f.AssertNoResourceExists("invalid-name", "", &v1alpha1.Kepler{})
 	kepler := f.NewKepler("invalid-name")
 	err := f.Patch(&kepler)
 	assert.ErrorContains(t, err, "denied the request")


### PR DESCRIPTION
This commit updates the test framework to use wait.PollUntilContextTimeout instead of wait.PollImmediate, as the latter is deprecated.