### PR TITLE
chore: bump up oc cli version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY internal/ internal/
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
   go build -a -o manager cmd/main.go
 
-FROM quay.io/openshift/origin-cli:4.13 AS origincli
+FROM quay.io/openshift/origin-cli:4.18 AS origincli
 
 FROM registry.access.redhat.com/ubi9-minimal:9.2
 RUN INSTALL_PKGS=" \

--- a/hack/dashboard/openshift/deploy-grafana.sh
+++ b/hack/dashboard/openshift/deploy-grafana.sh
@@ -45,7 +45,7 @@ validate_cluster() {
 		fail "No oc command found in PATH"
 		info "Please install oc"
 		cat <<-EOF
-			curl -sNL https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.16.0/openshift-client-linux.tar.gz |
+			curl -sNL https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.18.1/openshift-client-linux.tar.gz |
 			  tar -xzf - -C <install/path>
 		EOF
 		# NOTE: do not proceed without oc installed
@@ -68,7 +68,7 @@ validate_cluster() {
 		fail "oc version '$oc_version' should be at least 4.12.0"
 		info "install a newer version of oc"
 		cat <<-EOF
-			curl -sNL https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.13.0/openshift-client-linux.tar.gz |
+			curl -sNL https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.18.1/openshift-client-linux.tar.gz |
 			  tar -xzf - -C <install/path>
 		EOF
 		ret=1


### PR DESCRIPTION
This commit bumps up the oc cli version to 4.18