### PR TITLE
ci: use correct coverage file

### DIFF
--- a/.github/codecov-upload/action.yaml
+++ b/.github/codecov-upload/action.yaml
@@ -15,5 +15,5 @@ runs:
       uses: codecov/codecov-action@v5.4.0
       with:
         fail_ci_if_error: true
-        files: ./cov.out
+        files: ./cover.out
         token: ${{ inputs.codecov_token }}


### PR DESCRIPTION
This commit fixes the issue where the wrong coverage file was being referenced in the codecov-upload action.