### PR TITLE
chore: add make target for generating coverage html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Dockerfile.cross
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+*.html
 
 # Kubernetes Generated files - skip generated files, except for vendored files
 

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,10 @@ vet: ## Run go vet against code.
 test:  fmt vet  ## Run tests.
 		go test ./pkg/... -coverprofile cover.out
 
+.PHONY: coverage
+coverage: test ## Run tests and generate coverage report.
+	go tool cover -html=cover.out -o cover.html
+
 .PHONY: docs
 docs: crdoc manifests ## Generate docs.
 	$(CRDOC) --resources config/crd/bases --output docs/api.md


### PR DESCRIPTION
This commit adds a `coverage` target that generates a coverage html report which can be viewed to see the coverage of the code.