### PR TITLE
chore: bump up kepler reboot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null)
 
 KEPLER_VERSION ?=release-0.7.12
-KEPLER_REBOOT_VERSION ?=v0.0.4
+KEPLER_REBOOT_VERSION ?=v0.0.5
 
 # IMG_BASE and KEPLER_IMG_BASE are set to distinguish between Operator-specific images and Kepler-Specific images.
 # IMG_BASE is used for building and pushing operator related images.

--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.15.0
-    createdAt: "2025-04-24T14:16:03Z"
+    createdAt: "2025-04-29T10:44:23Z"
     description: Deploys and Manages Kepler on Kubernetes
     operators.operatorframework.io/builder: operator-sdk-v1.39.1
     operators.operatorframework.io/internal-objects: |-
@@ -268,7 +268,7 @@ spec:
                 - name: RELATED_IMAGE_KEPLER
                   value: quay.io/sustainable_computing_io/kepler:release-0.7.12
                 - name: RELATED_IMAGE_KEPLER_REBOOT
-                  value: quay.io/sustainable_computing_io/kepler-reboot:v0.0.4
+                  value: quay.io/sustainable_computing_io/kepler-reboot:v0.0.5
                 image: quay.io/sustainable_computing_io/kepler-operator:0.15.0
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
@@ -378,7 +378,7 @@ spec:
   relatedImages:
   - image: quay.io/sustainable_computing_io/kepler:release-0.7.12
     name: kepler
-  - image: quay.io/sustainable_computing_io/kepler-reboot:v0.0.4
+  - image: quay.io/sustainable_computing_io/kepler-reboot:v0.0.5
     name: kepler-reboot
   replaces: kepler-operator.v0.14.0
   version: 0.15.0

--- a/internal/config/config_rapl_test.go
+++ b/internal/config/config_rapl_test.go
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRaplConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	assert.Empty(t, cfg.Rapl.Zones, "rapl zones should be empty by default")
+}
+
+// TestLoadRaplConfigFromYAML tests loading rapl configuration from YAML
+func TestLoadRaplConfigFromYAML(t *testing.T) {
+	tt := []struct {
+		name     string
+		yamlData string
+		zones    []string
+	}{
+		{"empty", ``, []string{}},
+		{
+			"only-pkg",
+			`
+rapl:
+  zones:
+  - package
+`,
+			[]string{"package"},
+		},
+		{
+			"2 zones",
+			`
+rapl:
+  zones:
+  - package
+  - core
+`,
+			[]string{"package", "core"},
+		},
+		{
+			"sanitize",
+			`
+rapl:
+  zones:
+  - "package  "
+  - "  core"
+`,
+			[]string{"package", "core"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			reader := strings.NewReader(tc.yamlData)
+			cfg, err := Load(reader)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.zones, cfg.Rapl.Zones)
+		})
+	}
+}
+
+// TestEmptyRaplConfigFromYAML tests loading an empty rapl configuration (keeps defaults)
+func TestEmptyRaplConfigFromYAML(t *testing.T) {
+	reader := strings.NewReader(``)
+	cfg, err := Load(reader)
+	assert.NoError(t, err)
+
+	// Verify all values are defaults
+	defaultCfg := DefaultConfig()
+	assert.Equal(t, defaultCfg.Rapl.Zones, cfg.Rapl.Zones)
+}
+
+// TestComplexRaplConfig tests loading complex rapl configuration
+func TestComplexRaplConfig(t *testing.T) {
+	yamlData := `
+rapl:
+  zones:
+    - package
+    - core
+    - dram
+`
+	// Load config from YAML
+	reader := strings.NewReader(yamlData)
+	cfg, err := Load(reader)
+	assert.NoError(t, err)
+
+	// Verify configuration values
+	assert.Equal(t, []string{"package", "core", "dram"}, cfg.Rapl.Zones)
+	assert.Len(t, cfg.Rapl.Zones, 3)
+}
+
+func TestRaplConfigString(t *testing.T) {
+	cfg := &Config{
+		Rapl: Rapl{
+			Zones: []string{"package", "core"},
+		},
+	}
+
+	str := cfg.String()
+	assert.Contains(t, str, "rapl:")
+	assert.Contains(t, str, "- package")
+	assert.Contains(t, str, "- core")
+
+	// Test manual string method
+	manualStr := cfg.manualString()
+	assert.Contains(t, manualStr, "rapl.zones: package, core")
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -379,3 +379,47 @@ func TestConfigString(t *testing.T) {
 		})
 	}
 }
+
+func TestEnablePprof(t *testing.T) {
+	tt := []struct {
+		name    string
+		args    []string
+		enabled bool
+	}{{
+		name:    "enable pprof with flag",
+		args:    []string{"--enable.pprof"},
+		enabled: true,
+	}, {
+		name:    "disable pprof no flag",
+		args:    []string{"--log.level=debug"},
+		enabled: false,
+	}, {
+		name:    "disable pprof with flag",
+		args:    []string{"--no-enable.pprof"},
+		enabled: false,
+	}}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			app := kingpin.New("test", "Test application")
+			updateConfig := RegisterFlags(app)
+			_, parseErr := app.Parse(tc.args)
+			assert.NoError(t, parseErr, "unexpected flag parsing error")
+			cfg := DefaultConfig()
+			err := updateConfig(cfg)
+			assert.NoError(t, err, "unexpected config update error")
+			assert.Equal(t, cfg.EnablePprof, tc.enabled, "unexpected flag value")
+		})
+	}
+}
+
+func TestValidateWithSkip(t *testing.T) {
+	// Create a config with invalid host paths
+	cfg := DefaultConfig()
+	cfg.Host.SysFS = "/path/invalid"
+	cfg.Host.ProcFS = "/path/invalid"
+
+	// Validate with skipping host validation
+	err := cfg.Validate(SkipHostValidation)
+	assert.NoError(t, err, "Should pass when SkipHostValidation is provided")
+}

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -13,7 +13,7 @@ var Config = struct {
 	Image       string
 	Cluster     k8s.Cluster
 }{
-	RebootImage: "quay.io/sustainable_computing_io/kepler-reboot:v0.0.4",
+	RebootImage: "quay.io/sustainable_computing_io/kepler-reboot:v0.0.5",
 	Image:       "",
 	Cluster:     k8s.Kubernetes,
 }


### PR DESCRIPTION
This commit bumps up Kepler reboot version to v0.0.5
It also copy the config package from Kepler so that we can use the config available in Operator

