### PR TITLE
ci: add dedicated go vet job to pr checks

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -8,12 +8,14 @@ jobs:
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@main
+
       - uses: actions/setup-go@main
         with:
           go-version-file: go.mod
 
       - name: Install all tools
         uses: ./.github/tools-cache
+
       - name: make docs
         run: |
           make docs
@@ -23,18 +25,37 @@ jobs:
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@main
+
       - uses: actions/setup-go@main
         with:
           go-version-file: go.mod
+
       - name: Install all tools
         uses: ./.github/tools-cache
+
       - name: make fmt
         run: make fmt && git diff --exit-code
+
+  vet:
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - uses: actions/checkout@main
+
+      - uses: actions/setup-go@main
+        with:
+          go-version-file: go.mod
+
+      - name: Install all tools
+        uses: ./.github/tools-cache
+
+      - name: make vet
+        run: make vet && git diff --exit-code
 
   escapes_detect:
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@main
+
       - uses: actions/setup-go@main
         with:
           go-version-file: go.mod
@@ -110,7 +131,6 @@ jobs:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   bundle:
-    needs: [docs, golangci, fmt, vulnerability_detect, escapes_detect]
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@main
@@ -126,7 +146,6 @@ jobs:
           git diff --exit-code
 
   build-images:
-    needs: [docs, golangci, fmt, vulnerability_detect, escapes_detect]
     runs-on: ubuntu-latest-16-cores
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ cluster-down: ## delete the local development cluster
 ##@ Build
 
 .PHONY: build
-build: manifests generate fmt vet ## Build manager binary.
+build: manifests generate ## Build manager binary.
 	CGO_ENABLED=0 go build $(LDFLAGS) -o bin/manager ./cmd/...
 
 OPENSHIFT ?= true


### PR DESCRIPTION
This commit removes `go fmt` and `go vet` dependencies from `make build`. It adds a go vet job to PR check workflow, matching go fmt setup. It also updates the build-bundle and build-images jobs to run without any dependencies.