### PR TITLE
ci: run jobs based on file changes

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -4,6 +4,23 @@ on:
   pull_request:
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      changes: ${{ steps.filter.outputs.changes }}
+    steps:
+      - name: checkout source
+        uses: actions/checkout@v4
+
+      - name: filter changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            changes:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
   docs:
     runs-on: ubuntu-latest-8-cores
     steps:
@@ -52,6 +69,7 @@ jobs:
         run: make vet && git diff --exit-code
 
   escapes_detect:
+    if: needs.check-changes.outputs.changes == 'true'
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@main
@@ -67,6 +85,7 @@ jobs:
         run: make escapes_detect
 
   golangci:
+    if: needs.check-changes.outputs.changes == 'true'
     permissions:
       contents: read
       # NOTE: allow read access to pull request. Use with `only-new-issues` option.
@@ -89,6 +108,7 @@ jobs:
           only-new-issues: true
 
   vulnerability_detect:
+    if: needs.check-changes.outputs.changes == 'true'
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@main
@@ -115,6 +135,7 @@ jobs:
         uses: pre-commit/action@v3.0.1
 
   codecov-upload:
+    if: needs.check-changes.outputs.changes == 'true'
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@main

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -8,12 +8,14 @@ jobs:
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@main
+
       - uses: actions/setup-go@main
         with:
           go-version-file: go.mod
 
       - name: Install all tools
         uses: ./.github/tools-cache
+
       - name: make docs
         run: |
           make docs
@@ -23,18 +25,37 @@ jobs:
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@main
+
       - uses: actions/setup-go@main
         with:
           go-version-file: go.mod
+
       - name: Install all tools
         uses: ./.github/tools-cache
+
       - name: make fmt
         run: make fmt && git diff --exit-code
+
+  vet:
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - uses: actions/checkout@main
+
+      - uses: actions/setup-go@main
+        with:
+          go-version-file: go.mod
+
+      - name: Install all tools
+        uses: ./.github/tools-cache
+
+      - name: make vet
+        run: make vet && git diff --exit-code
 
   escapes_detect:
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@main
+
       - uses: actions/setup-go@main
         with:
           go-version-file: go.mod
@@ -110,7 +131,6 @@ jobs:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   bundle:
-    needs: [docs, golangci, fmt, vulnerability_detect, escapes_detect]
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@main
@@ -126,7 +146,6 @@ jobs:
           git diff --exit-code
 
   build-images:
-    needs: [docs, golangci, fmt, vulnerability_detect, escapes_detect]
     runs-on: ubuntu-latest-16-cores
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ cluster-down: ## delete the local development cluster
 ##@ Build
 
 .PHONY: build
-build: manifests generate fmt vet ## Build manager binary.
+build: manifests generate ## Build manager binary.
 	CGO_ENABLED=0 go build $(LDFLAGS) -o bin/manager ./cmd/...
 
 OPENSHIFT ?= true


### PR DESCRIPTION
This commit adds a check-changes job to the pr-check workflow which will check if any of the go files have been changed/added/removed. If any changes are detected, the workflow will run all the golang specific jobs (escape_detect, golangci, vulnerability_detect, codecov)