### PR TITLE
test: update e2e script to accept commands

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -193,7 +193,7 @@ jobs:
       - name: Run Operator Upgrade
         shell: bash
         run: |
-          ./tests/run-e2e.sh --ci
+          ./tests/run-e2e.sh upgrade-test
         env:
           VERSION: ${{ steps.version.outputs.version }}
 
@@ -254,7 +254,7 @@ jobs:
 
       - name: Run e2e tests
         run: |
-          ./tests/run-e2e.sh --ci --no-upgrade --enable-vm-test
+          ./tests/run-e2e.sh e2e --ci --enable-vm-test
         env:
           VERSION: ${{ steps.version.outputs.version }}
 


### PR DESCRIPTION
This commit updates the e2e script to now accept commands to run the e2e tests. Now we can run e2e tests with the following commands:
```
./tests/run.sh upgrade-test
./test/run.sh e2e [args for e2e]
```

Addresses: #485 