### PR TITLE
ci: ensure go vet job also runs on file change

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -54,6 +54,7 @@ jobs:
         run: make fmt && git diff --exit-code
 
   vet:
+    if: needs.check-changes.outputs.changes == 'true'
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@main


### PR DESCRIPTION
This commit adds the missing file check for the go vet job