### PR TITLE
Fix yaml error during the script run on "./hack/dashboard/openshift/deploy-grafana.sh"

### DIFF
--- a/hack/dashboard/openshift/grafana-config/01-grafana-instance.yaml
+++ b/hack/dashboard/openshift/grafana-config/01-grafana-instance.yaml
@@ -15,12 +15,12 @@ spec:
         name: kepler-grafana-service
         weight: 100
   ingress:
-    enabled: true
+    enabled: "True"
   config:
     auth:
-      disable_signout_menu: true
+      disable_signout_menu: "True"
     auth.anonymous:
-      enabled: true
+      enabled: "True"
     log:
       level: warn
       mode: console

--- a/hack/dashboard/openshift/grafana-config/03-grafana-datasource-UPDATETHIS.yaml
+++ b/hack/dashboard/openshift/grafana-config/03-grafana-datasource-UPDATETHIS.yaml
@@ -21,8 +21,8 @@ spec:
       httpHeaderValue1: Bearer ${BEARER_TOKEN}
     type: prometheus
     url: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
-name: prometheus-grafanadatasource.yaml
-# The spec.instanceSelectors field is used to tell the operator which Grafana instance the resource applies to.
-instanceSelector:
-  matchLabels:
-    dashboards: kepler-grafana
+  name: prometheus-grafanadatasource.yaml
+  # The spec.instanceSelectors field is used to tell the operator which Grafana instance the resource applies to.
+  instanceSelector:
+    matchLabels:
+      dashboards: kepler-grafana


### PR DESCRIPTION

When executing the script "./hack/dashboard/openshift/deploy-grafana.sh", we get following errors:

```
...
...
 🔔 Creating a grafana instance
 ❯ oc apply -n kepler-grafana -f hack/dashboard/openshift/grafana-config/01-grafana-instance.yaml

The Grafana "kepler-grafana" is invalid:
* spec.config.auth.disable_signout_menu: Invalid value: "boolean": spec.config.auth.disable_signout_menu in body must be of type string: "boolean"
* spec.config.auth.anonymous.enabled: Invalid value: "boolean": spec.config.auth.anonymous.enabled in body must be of type string: "boolean"
* <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation
...
...
 🔔 Creating datasource
 ❯ oc -n kepler-grafana create token --duration=8760h grafana

The GrafanaDatasource "prometheus-grafanadatasource" is invalid:
* spec.instanceSelector: Required value
* <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation

```

This PR is to fix the above errors on the `Invalid value: "boolean"` and `Invalid value: "null"`.

Thank you.
