### PR TITLE
chore: bump up supported ocp version for the operator

### DIFF
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -14,4 +14,4 @@ annotations:
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
 # Annotations for OpenShift version
-  com.redhat.openshift.versions: "v4.12-v4.17"
+  com.redhat.openshift.versions: "v4.16-v4.19"

--- a/hack/bundle.sh
+++ b/hack/bundle.sh
@@ -78,7 +78,7 @@ main() {
 	info "Adding additional metadata annotations"
 	cat <<-EOF >>bundle/metadata/annotations.yaml
 		# Annotations for OpenShift version
-		  com.redhat.openshift.versions: "v4.12-v4.17"
+		  com.redhat.openshift.versions: "v4.16-v4.19"
 	EOF
 
 	run operator-sdk bundle validate ./bundle \


### PR DESCRIPTION
This commit bumps up the supported ocp version for the operator to `4.16-4.19`