### PR TITLE
tests(power-monitor): replace enable_vm_test env variable with command-line flag

### DIFF
--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -23,7 +23,7 @@ var (
 	testKeplerImage       string
 	testKeplerRebootImage string
 	vmAnnotationKey       string
-	enableVMEnv           string
+	enableVMTest          bool
 )
 
 func TestMain(m *testing.M) {
@@ -33,12 +33,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&testKeplerImage, "kepler-image", keplerImage, "Kepler image to use when running Internal tests")
 	flag.StringVar(&testKeplerRebootImage, "kepler-reboot-image", keplerRebootImage, "Kepler image to use when running PowerMonitorInternal tests")
 	flag.StringVar(&vmAnnotationKey, "vm-annotation-key", ciTestVMEnvKey, "VM Annotation Key set to enable vm test environment")
-	enableFakeMeter := "false"
-	if os.Getenv("ENABLE_VM_TEST") == "true" {
-		enableFakeMeter = "true"
-	}
-	flag.StringVar(&enableVMEnv, "enable-vm-env", enableFakeMeter, "Flag to set when enabling vm test environment")
-
+	flag.BoolVar(&enableVMTest, "enable-vm-test", false, "Enable VM test environment")
 	flag.Parse()
 
 	if *openshift {

--- a/tests/e2e/power_monitor_internal_test.go
+++ b/tests/e2e/power_monitor_internal_test.go
@@ -4,6 +4,7 @@
 package e2e
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -31,7 +32,7 @@ func TestPowerMonitorInternal_Reconciliation(t *testing.T) {
 		b.WithNamespace(testNs),
 		b.WithKeplerImage(testKeplerRebootImage),
 		b.WithCluster(Cluster),
-		b.WithAnnotation(vmAnnotationKey, enableVMEnv),
+		b.WithAnnotation(vmAnnotationKey, strconv.FormatBool(enableVMTest)),
 	)
 
 	// then the following resources will be created

--- a/tests/e2e/power_monitor_test.go
+++ b/tests/e2e/power_monitor_test.go
@@ -4,6 +4,7 @@
 package e2e
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -22,7 +23,7 @@ func TestPowerMonitor_Deletion(t *testing.T) {
 	f := test.NewFramework(t)
 
 	// pre-condition: ensure powermonitor exists
-	f.CreatePowerMonitor("power-monitor", f.WithPowerMonitorAnnotation(vmAnnotationKey, enableVMEnv))
+	f.CreatePowerMonitor("power-monitor", f.WithPowerMonitorAnnotation(vmAnnotationKey, strconv.FormatBool(enableVMTest)))
 	pm := f.WaitUntilPowerMonitorCondition("power-monitor", v1alpha1.Available, v1alpha1.ConditionTrue)
 
 	//
@@ -48,7 +49,7 @@ func TestPowerMonitor_Reconciliation(t *testing.T) {
 	f.AssertNoResourceExists("power-monitor", "", &v1alpha1.PowerMonitor{})
 
 	// when
-	pm := f.CreatePowerMonitor("power-monitor", f.WithPowerMonitorAnnotation(vmAnnotationKey, enableVMEnv))
+	pm := f.CreatePowerMonitor("power-monitor", f.WithPowerMonitorAnnotation(vmAnnotationKey, strconv.FormatBool(enableVMTest)))
 
 	// then
 	f.AssertResourceExists(controller.PowerMonitorDeploymentNS, "", &corev1.Namespace{})
@@ -95,7 +96,7 @@ func TestPowerMonitorNodeSelector(t *testing.T) {
 
 	pm := f.CreatePowerMonitor("power-monitor",
 		f.WithPowerMonitorNodeSelector(labels),
-		f.WithPowerMonitorAnnotation(vmAnnotationKey, enableVMEnv))
+		f.WithPowerMonitorAnnotation(vmAnnotationKey, strconv.FormatBool(enableVMTest)))
 
 	f.AssertResourceExists(controller.PowerMonitorDeploymentNS, "", &corev1.Namespace{})
 	ds := appsv1.DaemonSet{}
@@ -119,7 +120,7 @@ func TestPowerMonitorNodeSelectorUnavailableLabel(t *testing.T) {
 
 	pm := f.CreatePowerMonitor("power-monitor",
 		f.WithPowerMonitorNodeSelector(unavailableLabels),
-		f.WithPowerMonitorAnnotation(vmAnnotationKey, enableVMEnv))
+		f.WithPowerMonitorAnnotation(vmAnnotationKey, strconv.FormatBool(enableVMTest)))
 
 	f.AssertResourceExists(controller.PowerMonitorDeploymentNS, "", &corev1.Namespace{})
 	ds := appsv1.DaemonSet{}
@@ -155,7 +156,7 @@ func TestPowerMonitorTaint_WithToleration(t *testing.T) {
 
 	pm := f.CreatePowerMonitor("power-monitor",
 		f.WithPowerMonitorTolerations(append(node.Spec.Taints, e2eTestTaint)),
-		f.WithPowerMonitorAnnotation(vmAnnotationKey, enableVMEnv))
+		f.WithPowerMonitorAnnotation(vmAnnotationKey, strconv.FormatBool(enableVMTest)))
 	f.AssertResourceExists(controller.PowerMonitorDeploymentNS, "", &corev1.Namespace{})
 	ds := appsv1.DaemonSet{}
 	f.AssertResourceExists(pm.Name, controller.PowerMonitorDeploymentNS, &ds)
@@ -193,7 +194,7 @@ func TestBadPowerMonitorTaint_WithToleration(t *testing.T) {
 
 	pm := f.CreatePowerMonitor("power-monitor",
 		f.WithPowerMonitorTolerations(append(node.Spec.Taints, badTestTaint)),
-		f.WithPowerMonitorAnnotation(vmAnnotationKey, enableVMEnv))
+		f.WithPowerMonitorAnnotation(vmAnnotationKey, strconv.FormatBool(enableVMTest)))
 
 	f.AssertResourceExists(controller.PowerMonitorDeploymentNS, "", &corev1.Namespace{})
 	ds := appsv1.DaemonSet{}

--- a/tests/run-e2e.sh
+++ b/tests/run-e2e.sh
@@ -18,7 +18,6 @@ declare -r OPERATOR_CSV="bundle/manifests/$OPERATOR.clusterserviceversion.yaml"
 declare -r OPERATOR_DEPLOY_NAME="kepler-operator-controller"
 declare -r OPERATOR_RELEASED_BUNDLE="quay.io/sustainable_computing_io/$OPERATOR-bundle"
 declare -r TEST_IMAGES_YAML="tests/images.yaml"
-declare ENABLE_VM_TEST
 
 declare IMG_BASE="${IMG_BASE:-localhost:5001/$OPERATOR}"
 # NOTE: this vars are initialized in init_operator_img
@@ -29,6 +28,7 @@ declare CI_MODE=false
 declare NO_DEPLOY=false
 declare NO_BUILDS=false
 declare SHOW_USAGE=false
+declare ENABLE_VM_TEST=false
 declare LOGS_DIR="tmp/e2e"
 declare OPERATORS_NS="operators"
 declare TEST_TIMEOUT="15m"
@@ -213,6 +213,7 @@ run_e2e() {
 	local ret=0
 	run go test -v -failfast -timeout $TEST_TIMEOUT \
 		./tests/e2e/... "$@" \
+		-enable-vm-test=$ENABLE_VM_TEST \
 		2>&1 | tee "$LOGS_DIR/e2e.log" || ret=1
 
 	# terminate both log_events
@@ -261,8 +262,7 @@ parse_args() {
 			shift
 			;;
 		--enable-vm-test)
-			ENABLE_VM_TEST="true"
-			export ENABLE_VM_TEST # export vm test results
+			ENABLE_VM_TEST=true
 			shift
 			;;
 		--image-base)


### PR DESCRIPTION
Initially, enable_vm_test was populated using an enviornment variable. This was replaced with a command-line flag instead as it was more explicit.