### PR TITLE
test: use latest kepler release

### DIFF
--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	keplerImage       = `quay.io/sustainable_computing_io/kepler:release-0.7.12`
-	keplerRebootImage = `quay.io/sustainable_computing_io/kepler-reboot:v0.0.4`
+	keplerRebootImage = `quay.io/sustainable_computing_io/kepler-reboot:v0.0.5`
 	ciTestVMEnvKey    = `powermonitor.sustainable.computing.io/test-env-vm`
 )
 


### PR DESCRIPTION
This commit makes use of the latest kepler release when running Power Monitor Internal tests

Addresses #508 