### PR TITLE
chore: implement builder pattern for config merging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.23
 toolchain go1.23.3
 
 require (
+	dario.cat/mergo v1.0.0
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/go-logr/logr v1.4.2
-	github.com/imdario/mergo v0.3.6
 	github.com/openshift/api v0.0.0-20240212125214-04ea3891d9cb
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.71.2
 	github.com/stretchr/testify v1.9.0
@@ -50,6 +50,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
+	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
+dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjHpqDjYY=
 github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -700,286 +700,79 @@ debug:
 	assert.True(t, cfg.Debug.Pprof.Enabled, "pprof should be enabled")
 }
 
-func TestConfigMerge(t *testing.T) {
-	tt := []struct {
-		name          string
-		defaultCfg    *Config
-		additionalCfg *Config
-		expectedCfg   *Config
-	}{
-		{
-			name: "merge with empty additional config",
-			defaultCfg: &Config{
-				Log: Log{
-					Level:  "info",
-					Format: "text",
-				},
-				Host: Host{
-					SysFS:  "/sys",
-					ProcFS: "/proc",
-				},
-			},
-			additionalCfg: &Config{},
-			expectedCfg: &Config{
-				Log: Log{
-					Level:  "info",
-					Format: "text",
-				},
-				Host: Host{
-					SysFS:  "/sys",
-					ProcFS: "/proc",
-				},
-			},
-		},
-		{
-			name: "merge with additional config",
-			defaultCfg: &Config{
-				Log: Log{
-					Level:  "info",
-					Format: "text",
-				},
-				Host: Host{
-					SysFS:  "/sys",
-					ProcFS: "/proc",
-				},
-			},
-			additionalCfg: &Config{
-				Log: Log{
-					Level:  "debug",
-					Format: "json",
-				},
-			},
-			expectedCfg: &Config{
-				Log: Log{
-					Level:  "debug",
-					Format: "json",
-				},
-				Host: Host{
-					SysFS:  "/sys",
-					ProcFS: "/proc",
-				},
-			},
-		},
-		{
-			name: "merge with partial additional config",
-			defaultCfg: &Config{
-				Log: Log{
-					Level:  "info",
-					Format: "text",
-				},
-				Host: Host{
-					SysFS:  "/sys",
-					ProcFS: "/proc",
-				},
-			},
-			additionalCfg: &Config{
-				Log: Log{
-					Level: "debug",
-				},
-				Host: Host{
-					SysFS: "/custom/sys",
-				},
-			},
-			expectedCfg: &Config{
-				Log: Log{
-					Level:  "debug",
-					Format: "text",
-				},
-				Host: Host{
-					SysFS:  "/custom/sys",
-					ProcFS: "/proc",
-				},
-			},
-		},
-	}
+func TestMergeConfig(t *testing.T) {
+	// Test merge with default
+	t.Run("MergeWithDefault", func(t *testing.T) {
+		b := &Builder{}
+		cfg, err := b.UseDefault().Build()
+		assert.NoError(t, err)
+		assert.Equal(t, "info", cfg.Log.Level)
+		assert.Equal(t, "text", cfg.Log.Format) // default
+	})
 
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.defaultCfg.merge(tc.additionalCfg)
-			assert.NoError(t, err)
-			assert.Equal(t, tc.expectedCfg.Log.Level, tc.defaultCfg.Log.Level)
-			assert.Equal(t, tc.expectedCfg.Log.Format, tc.defaultCfg.Log.Format)
-			assert.Equal(t, tc.expectedCfg.Host.SysFS, tc.defaultCfg.Host.SysFS)
-			assert.Equal(t, tc.expectedCfg.Host.ProcFS, tc.defaultCfg.Host.ProcFS)
-		})
-	}
-}
+	// Test merge without default
+	t.Run("MergeWithoutDefault", func(t *testing.T) {
+		b := &Builder{}
+		cfg, err := b.Build()
+		assert.NoError(t, err)
+		assert.Equal(t, "info", cfg.Log.Level)
+		assert.Equal(t, "text", cfg.Log.Format) // default
+	})
 
-func TestMergeAdditionalConfigs(t *testing.T) {
-	tt := []struct {
-		name        string
-		defaultCfg  *Config
-		additional  []string
-		expectedCfg *Config
-		hasError    bool
-	}{
-		{
-			name: "merge empty additional configs",
-			defaultCfg: &Config{
-				Log: Log{
-					Level:  "info",
-					Format: "text",
-				},
-			},
-			additional: []string{},
-			expectedCfg: &Config{
-				Log: Log{
-					Level:  "info",
-					Format: "text",
-				},
-				Host: Host{
-					SysFS:  "/sys",
-					ProcFS: "/proc",
-				},
-			},
-			hasError: false,
-		},
-		{
-			name: "merge one valid config",
-			defaultCfg: &Config{
-				Log: Log{
-					Level:  "info",
-					Format: "text",
-				},
-			},
-			additional: []string{`
+	// Test merge with invalid YAML
+	t.Run("MergeWithInvalidYAML", func(t *testing.T) {
+		b := &Builder{}
+		cfg, err := b.UseDefault().
+			Merge(`invalid yaml: [invalid`).
+			Build()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse YAML")
+		assert.Nil(t, cfg)
+	})
+
+	// Test multiple merges
+	t.Run("MultipleMerges", func(t *testing.T) {
+		b := &Builder{}
+		cfg, err := b.UseDefault().
+			Merge(`
 log:
   level: debug
-`},
-			expectedCfg: &Config{
-				Log: Log{
-					Level:  "debug",
-					Format: "text",
-				},
-				Host: Host{
-					SysFS:  "/sys",
-					ProcFS: "/proc",
-				},
-			},
-			hasError: false,
-		},
-		{
-			name: "merge multiple valid configs",
-			defaultCfg: &Config{
-				Log: Log{
-					Level:  "info",
-					Format: "text",
-				},
-				Host: Host{
-					SysFS:  "/sys",
-					ProcFS: "/proc",
-				},
-			},
-			additional: []string{
-				`log:
-  level: debug`,
-				`host:
-  sysfs: /custom/sys`,
-				`log:
-  format: json`,
-			},
-			expectedCfg: &Config{
-				Log: Log{
-					Level:  "debug",
-					Format: "json",
-				},
-				Host: Host{
-					SysFS:  "/custom/sys",
-					ProcFS: "/proc",
-				},
-			},
-			hasError: false,
-		},
-		{
-			name: "merge with one invalid config",
-			defaultCfg: &Config{
-				Log: Log{
-					Level:  "info",
-					Format: "text",
-				},
-			},
-			additional: []string{
-				`log:
-  level: debug`,
-				`{[invalid]yaml}`,
-			},
-			expectedCfg: &Config{
-				Log: Log{
-					Level:  "debug",
-					Format: "text",
-				},
-				Host: Host{
-					SysFS:  "/sys",
-					ProcFS: "/proc",
-				},
-			},
-			hasError: true,
-		},
-		{
-			name: "merge with empty string",
-			defaultCfg: &Config{
-				Log: Log{
-					Level:  "info",
-					Format: "text",
-				},
-			},
-			additional: []string{
-				"",
-			},
-			expectedCfg: &Config{
-				Log: Log{
-					Level:  "info",
-					Format: "text",
-				},
-				Host: Host{
-					SysFS:  "/sys",
-					ProcFS: "/proc",
-				},
-			},
-			hasError: false,
-		},
-		{
-			name: "merge with whitespace-only string",
-			defaultCfg: &Config{
-				Log: Log{
-					Level:  "info",
-					Format: "text",
-				},
-			},
-			additional: []string{
-				"   \t\n   ",
-			},
-			expectedCfg: &Config{
-				Log: Log{
-					Level:  "info",
-					Format: "text",
-				},
-				Host: Host{
-					SysFS:  "/sys",
-					ProcFS: "/proc",
-				},
-			},
-			hasError: false,
-		},
-	}
+`).
+			Merge(`
+log:
+  level: info
+`).
+			Build()
+		assert.NoError(t, err)
+		assert.Equal(t, "info", cfg.Log.Level) // last merge
+	})
 
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			defaultCfg := DefaultConfig()
-			err := MergeAdditionalConfigs(defaultCfg, tc.additional...)
+	// Test merge nested
+	t.Run("MergeNested", func(t *testing.T) {
+		b := &Builder{}
+		cfg, err := b.UseDefault().
+			Merge(`
+exporter:
+  prometheus:
+    enabled: false
+`).
+			Build()
+		assert.NoError(t, err)
+		assert.False(t, cfg.Exporter.Prometheus.Enabled)
+		assert.False(t, cfg.Exporter.Stdout.Enabled) // default
+	})
 
-			if tc.hasError {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), "failed to merge additional config")
-				return
-			}
-
-			assert.NoError(t, err)
-
-			assert.Equal(t, tc.expectedCfg.Log.Level, defaultCfg.Log.Level)
-			assert.Equal(t, tc.expectedCfg.Log.Format, defaultCfg.Log.Format)
-			assert.Equal(t, tc.expectedCfg.Host.SysFS, defaultCfg.Host.SysFS)
-			assert.Equal(t, tc.expectedCfg.Host.ProcFS, defaultCfg.Host.ProcFS)
-		})
-	}
+	// Test merge arrays
+	t.Run("MergeArrays", func(t *testing.T) {
+		b := &Builder{}
+		cfg, err := b.UseDefault().
+			Merge(`
+exporter:
+  prometheus:
+    debugCollectors: ["go", "process"]
+`).
+			Build()
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, []string{"go", "process"}, cfg.Exporter.Prometheus.DebugCollectors)
+	})
 }


### PR DESCRIPTION
This commit replaces the current MergeAdditionalConfigs implementation with a builder pattern. It also fixes boolean merging issue by switching from `mergo.WithOverride` to `mergo.WithOverwriteWithEmptyValue`, ensuring additional Config object mirror default content with modifications during YAML unmarshalling. This is a workaround for the issue https://github.com/darccio/mergo/issues/249.