### PR TITLE
ci: specify codecov secret to the workflow

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -143,6 +143,8 @@ jobs:
     needs: check-changes
     if: needs.check-changes.outputs.changes == 'true'
     uses: ./.github/workflows/test-and-codecov.yaml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   bundle:
     runs-on: ubuntu-latest-8-cores

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,4 +1,4 @@
-name: Publish Images
+name: Push
 
 on: # yamllint disable-line rule:truthy
   push:
@@ -7,6 +7,8 @@ on: # yamllint disable-line rule:truthy
 jobs:
   test-and-codecov:
     uses: ./.github/workflows/test-and-codecov.yaml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   publish:
     name: Publish operator container images

--- a/.github/workflows/test-and-codecov.yaml
+++ b/.github/workflows/test-and-codecov.yaml
@@ -2,6 +2,10 @@ name: Test and Upload Coverage
 
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        description: Codecov token
+        required: true
 
 jobs:
   test:


### PR DESCRIPTION
This commit fixes the issue where the codecov calling workflow needs secret to be passed explicitly.

It also renames the publish-images workflow to push workflow for better clarity.