### PR TITLE
chore: remove service monitor interval from powermonitor

### DIFF
--- a/pkg/components/power-monitor/deployment.go
+++ b/pkg/components/power-monitor/deployment.go
@@ -342,7 +342,6 @@ func NewPowerMonitorServiceMonitor(pmi *v1alpha1.PowerMonitorInternal) *monv1.Se
 		Spec: monv1.ServiceMonitorSpec{
 			Endpoints: []monv1.Endpoint{{
 				Port:           PowerMonitorServicePortName,
-				Interval:       "15s",
 				Scheme:         "http",
 				RelabelConfigs: relabelings,
 			}},


### PR DESCRIPTION
This commit removes the hard coded service monitor interval (15s) from the power-monitor