### PR TITLE
test: update the e2e to use config maps for VM test setup

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -290,7 +290,7 @@ jobs:
       # NOTE: Running only PowerMonitor test
       - name: Run e2e tests
         run: |
-          ./tests/run-e2e.sh e2e --ci --enable-vm-test -- -skip-kepler-tests
+          ./tests/run-e2e.sh e2e --ci -- -skip-kepler-tests -running-on-vm
         env:
           VERSION: ${{ steps.version.outputs.version }}
 

--- a/pkg/components/power-monitor/deployment.go
+++ b/pkg/components/power-monitor/deployment.go
@@ -38,7 +38,6 @@ const (
 	ProcFSMountPath     = "/host/proc"
 	KeplerConfigMapPath = "/etc/kepler"
 	KeplerConfigFile    = "config.yaml"
-	EnableVMTestKey     = "powermonitor.sustainable.computing.io/test-env-vm"
 
 	// ConfigMap annotations
 	ConfigMapHashAnnotation = "powermonitor.sustainable.computing.io/config-map-hash"
@@ -455,11 +454,6 @@ func KeplerConfig(pmi *v1alpha1.PowerMonitorInternal, additionalConfigs ...strin
 	cfg, err := b.Build()
 	if err != nil {
 		return "", fmt.Errorf("failed to build config: %w", err)
-	}
-
-	val, ok := pmi.Annotations[EnableVMTestKey]
-	if ok {
-		cfg.Dev.FakeCpuMeter.Enabled = ptr.To(val == "true")
 	}
 
 	cfg.Log.Level = pmi.Spec.Kepler.Config.LogLevel

--- a/pkg/components/power-monitor/deployment_test.go
+++ b/pkg/components/power-monitor/deployment_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sustainable.computing.io/kepler-operator/pkg/utils/k8s"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 )
 
 func TestPowerMonitorNodeSelection(t *testing.T) {
@@ -508,33 +507,6 @@ func TestKeplerConfig(t *testing.T) {
 		assert.Equal(t, defaultConfig.String(), configStr)
 	})
 
-	t.Run("With fake CPU meter enabled", func(t *testing.T) { // TODO: remove this test
-		pmi := &v1alpha1.PowerMonitorInternal{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "power-monitor-internal",
-				Annotations: map[string]string{
-					EnableVMTestKey: "true",
-				},
-			},
-			Spec: v1alpha1.PowerMonitorInternalSpec{
-				Kepler: v1alpha1.PowerMonitorInternalKeplerSpec{
-					Config: v1alpha1.PowerMonitorInternalKeplerConfigSpec{
-						LogLevel: "info",
-					},
-				},
-			},
-		}
-
-		configStr, err := KeplerConfig(pmi)
-
-		defaultConfig := config.DefaultConfig()
-		defaultConfig.Host.ProcFS = ProcFSMountPath
-		defaultConfig.Host.SysFS = SysFSMountPath
-		defaultConfig.Dev.FakeCpuMeter.Enabled = ptr.To(true)
-
-		assert.NoError(t, err)
-		assert.Equal(t, defaultConfig.String(), configStr)
-	})
 	t.Run("With invalid additional config", func(t *testing.T) {
 		pmi := &v1alpha1.PowerMonitorInternal{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/utils/test/framework.go
+++ b/pkg/utils/test/framework.go
@@ -488,16 +488,7 @@ func (f Framework) WithPowerMonitorTolerations(taints []corev1.Taint) func(k *v1
 	}
 }
 
-func (f Framework) WithPowerMonitorAnnotation(key, val string) func(k *v1alpha1.PowerMonitor) {
-	return func(pm *v1alpha1.PowerMonitor) {
-		if pm.Annotations == nil {
-			pm.Annotations = make(map[string]string)
-		}
-		pm.Annotations[key] = val
-	}
-}
-
-func (f Framework) WithPowerMonitorAdditionalConfigMaps(configMapNames []string) func(k *v1alpha1.PowerMonitor) {
+func (f Framework) WithAdditionalConfigMaps(configMapNames []string) func(k *v1alpha1.PowerMonitor) {
 	return func(pm *v1alpha1.PowerMonitor) {
 		var configMapRefs []v1alpha1.ConfigMapRef
 		for _, name := range configMapNames {
@@ -505,6 +496,23 @@ func (f Framework) WithPowerMonitorAdditionalConfigMaps(configMapNames []string)
 		}
 		pm.Spec.Kepler.Config.AdditionalConfigMaps = configMapRefs
 	}
+}
+
+func (f Framework) NewAdditionalConfigMap(configMapName, namespace, config string) *corev1.ConfigMap {
+	cm := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: namespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "ConfigMap",
+		},
+		Data: map[string]string{
+			"config.yaml": config,
+		},
+	}
+	return &cm
 }
 
 func (f Framework) GetSchedulableNodes() []corev1.Node {

--- a/pkg/utils/test/power_monitor_internal_builder.go
+++ b/pkg/utils/test/power_monitor_internal_builder.go
@@ -18,7 +18,7 @@ func (PowerMonitorInternalBuilder) WithNamespace(ns string) func(pmi *v1alpha1.P
 
 func (PowerMonitorInternalBuilder) WithKeplerImage(img string) func(pmi *v1alpha1.PowerMonitorInternal) {
 	return func(pmi *v1alpha1.PowerMonitorInternal) {
-		//k.Spec.Exporter.Deployment.Image = img
+		// k.Spec.Exporter.Deployment.Image = img
 		pmi.Spec.Kepler.Deployment.Image = img
 	}
 }
@@ -34,11 +34,12 @@ func (PowerMonitorInternalBuilder) WithCluster(c k8s.Cluster) func(pmi *v1alpha1
 	}
 }
 
-func (PowerMonitorInternalBuilder) WithAnnotation(key, val string) func(pmi *v1alpha1.PowerMonitorInternal) {
+func (PowerMonitorInternalBuilder) WithAdditionalConfigMaps(configMapNames []string) func(pmi *v1alpha1.PowerMonitorInternal) {
 	return func(pmi *v1alpha1.PowerMonitorInternal) {
-		if pmi.Annotations == nil {
-			pmi.Annotations = make(map[string]string)
+		var configMapRefs []v1alpha1.ConfigMapRef
+		for _, name := range configMapNames {
+			configMapRefs = append(configMapRefs, v1alpha1.ConfigMapRef{Name: name})
 		}
-		pmi.Annotations[key] = val
+		pmi.Spec.Kepler.Config.AdditionalConfigMaps = configMapRefs
 	}
 }

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -15,16 +15,14 @@ import (
 const (
 	keplerImage       = `quay.io/sustainable_computing_io/kepler:release-0.7.12`
 	keplerRebootImage = `quay.io/sustainable_computing_io/kepler-reboot:v0.0.9`
-	ciTestVMEnvKey    = `powermonitor.sustainable.computing.io/test-env-vm`
 )
 
 var (
 	Cluster               k8s.Cluster = k8s.Kubernetes
 	testKeplerImage       string
 	testKeplerRebootImage string
-	vmAnnotationKey       string
-	enableVMTest          bool
 	skipKeplerTests       bool
+	runningOnVM           bool
 )
 
 func TestMain(m *testing.M) {
@@ -33,9 +31,8 @@ func TestMain(m *testing.M) {
 		"Namespace where kepler and its components are deployed.")
 	flag.StringVar(&testKeplerImage, "kepler-image", keplerImage, "Kepler image to use when running Internal tests")
 	flag.StringVar(&testKeplerRebootImage, "kepler-reboot-image", keplerRebootImage, "Kepler image to use when running PowerMonitorInternal tests")
-	flag.StringVar(&vmAnnotationKey, "vm-annotation-key", ciTestVMEnvKey, "VM Annotation Key set to enable vm test environment")
-	flag.BoolVar(&enableVMTest, "enable-vm-test", false, "Enable VM test environment")
 	flag.BoolVar(&skipKeplerTests, "skip-kepler-tests", false, "Skip Kepler tests")
+	flag.BoolVar(&runningOnVM, "running-on-vm", false, "Enable VM test environment")
 	flag.Parse()
 
 	if *openshift {

--- a/tests/e2e/power_monitor_test.go
+++ b/tests/e2e/power_monitor_test.go
@@ -6,32 +6,47 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"testing"
 	"time"
+
+	// "strconv"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/sustainable.computing.io/kepler-operator/api/v1alpha1"
 	"github.com/sustainable.computing.io/kepler-operator/internal/controller"
-	"github.com/sustainable.computing.io/kepler-operator/pkg/components"
+
 	"github.com/sustainable.computing.io/kepler-operator/pkg/utils/k8s"
 	"github.com/sustainable.computing.io/kepler-operator/pkg/utils/test"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestPowerMonitor_Deletion(t *testing.T) {
 	f := test.NewFramework(t)
 
-	// pre-condition: ensure powermonitor exists
-	f.CreatePowerMonitor("power-monitor", f.WithPowerMonitorAnnotation(vmAnnotationKey, strconv.FormatBool(enableVMTest)))
+	// Pre-condition: Verify PowerMonitor doesn't exist
+	f.AssertNoResourceExists("power-monitor", "", &v1alpha1.PowerMonitor{})
+
+	// Create PowerMonitor
+	if runningOnVM {
+		configMapName := "my-custom-config"
+		f.CreatePowerMonitor("power-monitor", f.WithAdditionalConfigMaps([]string{configMapName}))
+		cfm := f.NewAdditionalConfigMap(configMapName, controller.PowerMonitorDeploymentNS, `dev:
+  fake-cpu-meter:
+    enabled: true`)
+		err := f.Patch(cfm)
+		assert.NoError(t, err)
+	} else {
+		f.CreatePowerMonitor("power-monitor")
+	}
+
+	// Wait until PowerMonitor is available
 	pm := f.WaitUntilPowerMonitorCondition("power-monitor", v1alpha1.Available, v1alpha1.ConditionTrue)
 
-	//
+	// Verify DaemonSet exists
 	ds := appsv1.DaemonSet{}
 	f.AssertResourceExists(
 		pm.Name,
@@ -39,48 +54,56 @@ func TestPowerMonitor_Deletion(t *testing.T) {
 		&ds,
 		test.Timeout(10*time.Second),
 	)
-
-	f.DeletePowerMonitor("power-monitor")
-
-	ns := components.NewNamespace(controller.PowerMonitorDeploymentNS)
-	f.AssertNoResourceExists(ns.Name, "", ns)
-	f.AssertNoResourceExists(ds.Name, ds.Namespace, &ds)
 }
 
 func TestPowerMonitor_Reconciliation(t *testing.T) {
 	f := test.NewFramework(t)
 
-	// pre-condition
+	// Pre-condition: Verify PowerMonitor doesn't exist
 	f.AssertNoResourceExists("power-monitor", "", &v1alpha1.PowerMonitor{})
 
-	// when
-	pm := f.CreatePowerMonitor("power-monitor", f.WithPowerMonitorAnnotation(vmAnnotationKey, strconv.FormatBool(enableVMTest)))
+	// Create PowerMonitor
+	if runningOnVM {
+		configMapName := "my-custom-config"
+		f.CreatePowerMonitor("power-monitor", f.WithAdditionalConfigMaps([]string{configMapName}))
+		cfm := f.NewAdditionalConfigMap(configMapName, controller.PowerMonitorDeploymentNS, `dev:
+  fake-cpu-meter:
+    enabled: true`)
+		err := f.Patch(cfm)
+		assert.NoError(t, err)
+	} else {
+		f.CreatePowerMonitor("power-monitor")
+	}
 
-	// then
+	// Verify reconciliation
+	pm := f.WaitUntilPowerMonitorCondition("power-monitor", v1alpha1.Reconciled, v1alpha1.ConditionTrue)
 	f.AssertResourceExists(controller.PowerMonitorDeploymentNS, "", &corev1.Namespace{})
 	ds := appsv1.DaemonSet{}
 	f.AssertResourceExists(pm.Name, controller.PowerMonitorDeploymentNS, &ds)
 
-	powermonitor := f.WaitUntilPowerMonitorCondition("power-monitor", v1alpha1.Reconciled, v1alpha1.ConditionTrue)
-	// default toleration
-	assert.Equal(t, []corev1.Toleration{{Operator: "Exists"}}, powermonitor.Spec.Kepler.Deployment.Tolerations)
-	reconciled, err := k8s.FindCondition(powermonitor.Status.Conditions, v1alpha1.Reconciled)
+	// Verify default toleration
+	assert.Equal(t, []corev1.Toleration{{Operator: "Exists"}}, pm.Spec.Kepler.Deployment.Tolerations)
+	reconciled, err := k8s.FindCondition(pm.Status.Conditions, v1alpha1.Reconciled)
 	assert.NoError(t, err, "unable to get reconciled condition")
-	assert.Equal(t, reconciled.ObservedGeneration, powermonitor.Generation)
+	assert.Equal(t, reconciled.ObservedGeneration, pm.Generation)
 	assert.Equal(t, reconciled.Status, v1alpha1.ConditionTrue)
 
-	powermonitor = f.WaitUntilPowerMonitorCondition("power-monitor", v1alpha1.Available, v1alpha1.ConditionTrue)
-	available, err := k8s.FindCondition(powermonitor.Status.Conditions, v1alpha1.Available)
+	// Verify available condition
+	pm = f.WaitUntilPowerMonitorCondition("power-monitor", v1alpha1.Available, v1alpha1.ConditionTrue)
+	available, err := k8s.FindCondition(pm.Status.Conditions, v1alpha1.Available)
 	assert.NoError(t, err, "unable to get available condition")
-	assert.Equal(t, available.ObservedGeneration, powermonitor.Generation)
+	assert.Equal(t, available.ObservedGeneration, pm.Generation)
 	assert.Equal(t, available.Status, v1alpha1.ConditionTrue)
 }
 
 func TestBadPowerMonitor_Reconciliation(t *testing.T) {
 	f := test.NewFramework(t)
-	// Ensure PowerMonitor is not deployed (by any chance)
+
+	// Pre-condition: Verify PowerMonitor doesn't exist
 	f.AssertNoResourceExists("power-monitor", "", &v1alpha1.PowerMonitor{}, test.Timeout(10*time.Second))
 	f.AssertNoResourceExists("invalid-name", "", &v1alpha1.PowerMonitor{})
+
+	// Attempt to create PowerMonitor with invalid name
 	powermonitor := f.NewPowerMonitor("invalid-name")
 	err := f.Patch(&powermonitor)
 	assert.ErrorContains(t, err, "denied the request")
@@ -88,99 +111,117 @@ func TestBadPowerMonitor_Reconciliation(t *testing.T) {
 
 func TestPowerMonitorNodeSelector(t *testing.T) {
 	f := test.NewFramework(t)
-	// Ensure PowerMonitor is not deployed (by any chance)
+
+	// Pre-condition: Verify PowerMonitor doesn't exist
 	f.AssertNoResourceExists("power-monitor", "", &v1alpha1.PowerMonitor{}, test.Timeout(10*time.Second))
 
+	// Label a node
 	nodes := f.GetSchedulableNodes()
 	assert.NotZero(t, len(nodes), "got zero nodes")
-
 	node := nodes[0]
 	var labels k8s.StringMap = map[string]string{"e2e-test": "true"}
 	err := f.AddResourceLabels("node", node.Name, labels)
 	assert.NoError(t, err, "could not label node")
 
-	pm := f.CreatePowerMonitor("power-monitor",
-		f.WithPowerMonitorNodeSelector(labels),
-		f.WithPowerMonitorAnnotation(vmAnnotationKey, strconv.FormatBool(enableVMTest)))
+	// Create PowerMonitor with node selector
+	if runningOnVM {
+		configMapName := "my-custom-config"
+		f.CreatePowerMonitor("power-monitor", f.WithAdditionalConfigMaps([]string{configMapName}),
+			f.WithPowerMonitorNodeSelector(labels))
+		cfm := f.NewAdditionalConfigMap(configMapName, controller.PowerMonitorDeploymentNS, `dev:
+  fake-cpu-meter:
+    enabled: true`)
+		err := f.Patch(cfm)
+		assert.NoError(t, err)
+	} else {
+		f.CreatePowerMonitor("power-monitor", f.WithPowerMonitorNodeSelector(labels))
+	}
 
+	// Verify PowerMonitor is available
+	pm := f.WaitUntilPowerMonitorCondition("power-monitor", v1alpha1.Available, v1alpha1.ConditionTrue)
 	f.AssertResourceExists(controller.PowerMonitorDeploymentNS, "", &corev1.Namespace{})
 	ds := appsv1.DaemonSet{}
 	f.AssertResourceExists(pm.Name, controller.PowerMonitorDeploymentNS, &ds)
-	powermonitor := f.WaitUntilPowerMonitorCondition("power-monitor", v1alpha1.Available, v1alpha1.ConditionTrue)
-	assert.EqualValues(t, 1, powermonitor.Status.Kepler.NumberAvailable)
-	f.DeletePowerMonitor("power-monitor")
-	f.AssertNoResourceExists(controller.PowerMonitorDeploymentNS, "", &corev1.Namespace{})
-	f.AssertNoResourceExists(ds.Name, ds.Namespace, &ds)
+	assert.EqualValues(t, 1, pm.Status.Kepler.NumberAvailable)
 }
 
 func TestPowerMonitorNodeSelectorUnavailableLabel(t *testing.T) {
 	f := test.NewFramework(t)
-	// Ensure PowerMonitor is not deployed (by any chance)
+
+	// Pre-condition: Verify PowerMonitor doesn't exist
 	f.AssertNoResourceExists("power-monitor", "", &v1alpha1.PowerMonitor{}, test.Timeout(10*time.Second))
 
+	// Verify nodes exist
 	nodes := f.GetSchedulableNodes()
 	assert.NotZero(t, len(nodes), "got zero nodes")
 
-	var unavailableLabels k8s.StringMap = map[string]string{"e2e-test": "true"}
+	// Create PowerMonitor with unavailable node selector
+	unavailableLabels := k8s.StringMap{"e2e-test": "true"}
+	if runningOnVM {
+		configMapName := "my-custom-config"
+		f.CreatePowerMonitor("power-monitor", f.WithAdditionalConfigMaps([]string{configMapName}), f.WithPowerMonitorNodeSelector(unavailableLabels))
+		cfm := f.NewAdditionalConfigMap(configMapName, controller.PowerMonitorDeploymentNS, `dev:
+  fake-cpu-meter:
+    enabled: true`)
+		err := f.Patch(cfm)
+		assert.NoError(t, err)
+	} else {
+		f.CreatePowerMonitor("power-monitor", f.WithPowerMonitorNodeSelector(unavailableLabels))
+	}
 
-	pm := f.CreatePowerMonitor("power-monitor",
-		f.WithPowerMonitorNodeSelector(unavailableLabels),
-		f.WithPowerMonitorAnnotation(vmAnnotationKey, strconv.FormatBool(enableVMTest)))
-
+	// Verify PowerMonitor is unavailable
+	pm := f.WaitUntilPowerMonitorCondition("power-monitor", v1alpha1.Available, v1alpha1.ConditionFalse)
 	f.AssertResourceExists(controller.PowerMonitorDeploymentNS, "", &corev1.Namespace{})
 	ds := appsv1.DaemonSet{}
 	f.AssertResourceExists(pm.Name, controller.PowerMonitorDeploymentNS, &ds)
-
-	powermonitor := f.WaitUntilPowerMonitorCondition("power-monitor", v1alpha1.Available, v1alpha1.ConditionFalse)
-	assert.EqualValues(t, 0, powermonitor.Status.Kepler.NumberAvailable)
-
-	f.DeletePowerMonitor("power-monitor")
-
-	f.AssertNoResourceExists(controller.PowerMonitorDeploymentNS, "", &corev1.Namespace{})
-	f.AssertNoResourceExists(ds.Name, ds.Namespace, &ds)
+	assert.EqualValues(t, 0, pm.Status.Kepler.NumberAvailable)
 }
 
 func TestPowerMonitorTaint_WithToleration(t *testing.T) {
 	f := test.NewFramework(t)
-	// Ensure PowerMonitor is not deployed (by any chance)
+
+	// Pre-condition: Verify PowerMonitor doesn't exist
 	f.AssertNoResourceExists("power-monitor", "", &v1alpha1.PowerMonitor{}, test.Timeout(10*time.Second))
 
-	var err error
-	// choose one node
+	// Taint a node
 	nodes := f.GetSchedulableNodes()
 	node := nodes[0]
-
 	e2eTestTaint := corev1.Taint{
 		Key:    "key1",
 		Value:  "value1",
 		Effect: corev1.TaintEffectNoSchedule,
 	}
-
-	err = f.TaintNode(node.Name, e2eTestTaint.ToString())
+	err := f.TaintNode(node.Name, e2eTestTaint.ToString())
 	assert.NoError(t, err, "failed to taint node %s", node)
 
-	pm := f.CreatePowerMonitor("power-monitor",
-		f.WithPowerMonitorTolerations(append(node.Spec.Taints, e2eTestTaint)),
-		f.WithPowerMonitorAnnotation(vmAnnotationKey, strconv.FormatBool(enableVMTest)))
+	// Create PowerMonitor with toleration
+	if runningOnVM {
+		configMapName := "my-custom-config"
+		f.CreatePowerMonitor("power-monitor", f.WithAdditionalConfigMaps([]string{configMapName}), f.WithPowerMonitorTolerations(append(node.Spec.Taints, e2eTestTaint)))
+		cfm := f.NewAdditionalConfigMap(configMapName, controller.PowerMonitorDeploymentNS, `dev:
+  fake-cpu-meter:
+    enabled: true`)
+		err := f.Patch(cfm)
+		assert.NoError(t, err)
+	} else {
+		f.CreatePowerMonitor("power-monitor", f.WithPowerMonitorTolerations(append(node.Spec.Taints, e2eTestTaint)))
+	}
+
+	// Verify PowerMonitor is available
+	pm := f.WaitUntilPowerMonitorCondition("power-monitor", v1alpha1.Available, v1alpha1.ConditionTrue)
 	f.AssertResourceExists(controller.PowerMonitorDeploymentNS, "", &corev1.Namespace{})
 	ds := appsv1.DaemonSet{}
 	f.AssertResourceExists(pm.Name, controller.PowerMonitorDeploymentNS, &ds)
-
-	powermonitor := f.WaitUntilPowerMonitorCondition("power-monitor", v1alpha1.Available, v1alpha1.ConditionTrue)
-	assert.EqualValues(t, len(nodes), powermonitor.Status.Kepler.NumberAvailable)
-
-	f.DeletePowerMonitor("power-monitor")
-
-	f.AssertNoResourceExists(controller.PowerMonitorDeploymentNS, "", &corev1.Namespace{})
-	f.AssertNoResourceExists(ds.Name, ds.Namespace, &ds)
+	assert.EqualValues(t, len(nodes), pm.Status.Kepler.NumberAvailable)
 }
 
 func TestBadPowerMonitorTaint_WithToleration(t *testing.T) {
 	f := test.NewFramework(t)
-	// Ensure PowerMonitor is not deployed (by any chance)
+
+	// Pre-condition: Verify PowerMonitor doesn't exist
 	f.AssertNoResourceExists("power-monitor", "", &v1alpha1.PowerMonitor{}, test.Timeout(10*time.Second))
 
-	// choose one node
+	// Taint a node
 	nodes := f.GetSchedulableNodes()
 	node := nodes[0]
 	e2eTestTaint := corev1.Taint{
@@ -193,92 +234,98 @@ func TestBadPowerMonitorTaint_WithToleration(t *testing.T) {
 		Value:  "value2",
 		Effect: corev1.TaintEffectNoSchedule,
 	}
-
 	err := f.TaintNode(node.Name, e2eTestTaint.ToString())
 	assert.NoError(t, err, "failed to taint node %s", node)
 
-	pm := f.CreatePowerMonitor("power-monitor",
-		f.WithPowerMonitorTolerations(append(node.Spec.Taints, badTestTaint)),
-		f.WithPowerMonitorAnnotation(vmAnnotationKey, strconv.FormatBool(enableVMTest)))
-
+	// Create PowerMonitor with incorrect toleration
+	if runningOnVM {
+		configMapName := "my-custom-config"
+		f.CreatePowerMonitor("power-monitor", f.WithAdditionalConfigMaps([]string{configMapName}), f.WithPowerMonitorTolerations(append(node.Spec.Taints, badTestTaint)))
+		cfm := f.NewAdditionalConfigMap(configMapName, controller.PowerMonitorDeploymentNS, `dev:
+  fake-cpu-meter:
+    enabled: true`)
+		err := f.Patch(cfm)
+		assert.NoError(t, err)
+	} else {
+		f.CreatePowerMonitor("power-monitor", f.WithPowerMonitorTolerations(append(node.Spec.Taints, badTestTaint)))
+	}
+	// Verify PowerMonitor is available but with reduced nodes
+	pm := f.WaitUntilPowerMonitorCondition("power-monitor", v1alpha1.Available, v1alpha1.ConditionTrue)
 	f.AssertResourceExists(controller.PowerMonitorDeploymentNS, "", &corev1.Namespace{})
 	ds := appsv1.DaemonSet{}
 	f.AssertResourceExists(pm.Name, controller.PowerMonitorDeploymentNS, &ds)
-
-	powermonitor := f.WaitUntilPowerMonitorCondition("power-monitor", v1alpha1.Available, v1alpha1.ConditionTrue)
-	assert.EqualValues(t, len(nodes)-1, powermonitor.Status.Kepler.NumberAvailable)
-
-	f.DeletePowerMonitor("power-monitor")
-
-	f.AssertNoResourceExists(controller.PowerMonitorDeploymentNS, "", &corev1.Namespace{})
-	f.AssertNoResourceExists(ds.Name, ds.Namespace, &ds)
+	assert.EqualValues(t, len(nodes)-1, pm.Status.Kepler.NumberAvailable)
 }
 
 func TestPowerMonitor_ReconciliationWithAdditionalConfigMap(t *testing.T) {
 	f := test.NewFramework(t)
 	configMapName := "my-custom-config"
 
+	// Pre-condition: Verify PowerMonitor doesn't exist
 	f.AssertNoResourceExists("power-monitor", "", &v1alpha1.PowerMonitor{})
 
-	pm := f.CreatePowerMonitor("power-monitor",
-		f.WithPowerMonitorAdditionalConfigMaps([]string{configMapName}),
-		f.WithPowerMonitorAnnotation(vmAnnotationKey, strconv.FormatBool(enableVMTest)))
+	// Create PowerMonitor with additional config map
+	pm := f.CreatePowerMonitor("power-monitor", f.WithAdditionalConfigMaps([]string{configMapName}))
 
-	f.AssertResourceExists(controller.PowerMonitorDeploymentNS, "", &corev1.Namespace{})
-
+	// Verify Daemonset doesn't exist
 	ds := appsv1.DaemonSet{}
 	f.AssertNoResourceExists(pm.Name, controller.PowerMonitorDeploymentNS, &ds)
 
-	// NOTE: condition should be false since the configmap is not created yet
+	// Verify reconcillation fails without config map
 	pm = f.WaitUntilPowerMonitorCondition("power-monitor", v1alpha1.Reconciled, v1alpha1.ConditionFalse)
 	reconciled, _ := k8s.FindCondition(pm.Status.Conditions, v1alpha1.Reconciled)
 	assert.Contains(t, reconciled.Message, fmt.Sprintf("configMap %s not found in %s namespace", configMapName, controller.PowerMonitorDeploymentNS))
 
-	// create custom configmap with additional config
-	customConfigMap := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      configMapName,
-			Namespace: controller.PowerMonitorDeploymentNS,
-		},
-		Data: map[string]string{
-			"config.yaml": `log:
+	// Create config map
+	conf := `log:
   format: json
-  level: debug`,
-		},
+  level: debug`
+
+	if runningOnVM {
+		conf += `
+dev:
+  fake-cpu-meter:
+    enabled: true`
 	}
-	err := f.Client().Create(context.TODO(), &customConfigMap)
+	cfm := f.NewAdditionalConfigMap(configMapName, controller.PowerMonitorDeploymentNS, conf)
+	err := f.Patch(cfm)
 	assert.NoError(t, err)
 
-	// wait for DaemonSet to be created
-	f.AssertResourceExists(pm.Name, controller.PowerMonitorDeploymentNS, &ds)
-
-	// expect reconcile to be true after configmap is created
+	// Verify reconcillation succeeds
 	pm = f.WaitUntilPowerMonitorCondition("power-monitor", v1alpha1.Reconciled, v1alpha1.ConditionTrue)
 
-	// verify that the main configmap contains merged configuration
+	// Verify Daemonset exists
+	f.AssertResourceExists(pm.Name, controller.PowerMonitorDeploymentNS, &ds)
+
+	// Verify merged config map
 	mainConfigMap := corev1.ConfigMap{}
 	f.AssertResourceExists(pm.Name, controller.PowerMonitorDeploymentNS, &mainConfigMap)
-
-	// check that the merged config contains both default and custom settings
 	configData := mainConfigMap.Data["config.yaml"]
 	assert.Contains(t, configData, "format: json", "custom log format should be merged")
 	assert.Contains(t, configData, "sysfs: /host/sys", "default sysfs path should be present")
 	assert.Contains(t, configData, "procfs: /host/proc", "default procfs path should be present")
 
-	// verify that DaemonSet has the config map hash annotation for rollout trigger
+	// Verify Daemonset annotation
 	assert.Contains(t, ds.Spec.Template.Annotations, "powermonitor.sustainable.computing.io/config-map-hash-"+pm.Name)
-
 	og := ds.Status.ObservedGeneration
 	assert.Equal(t, og, int64(1))
 
-	// update custom configmap to trigger rollout
-	customConfigMap.Data["config.yaml"] = `log:
+	// Update config map
+	updatedConf := `log:
   format: text
   level: warn`
-	err = f.Client().Update(context.TODO(), &customConfigMap)
+
+	if runningOnVM {
+		updatedConf += `
+dev:
+  fake-cpu-meter:
+    enabled: true`
+	}
+	cfm = f.NewAdditionalConfigMap(configMapName, controller.PowerMonitorDeploymentNS, updatedConf)
+	err = f.Patch(cfm)
 	assert.NoError(t, err)
 
-	// wait for DaemonSet to restart
+	// Wait for Daemonset restart
 	ds = appsv1.DaemonSet{}
 	f.WaitUntil("Daemonset to restart", func(ctx context.Context) (bool, error) {
 		err := f.Client().Get(ctx,
@@ -291,13 +338,13 @@ func TestPowerMonitor_ReconciliationWithAdditionalConfigMap(t *testing.T) {
 		return ds.Status.ObservedGeneration == og+1, nil
 	})
 
-	// verify updated config is merged
+	// Verify updated config
 	f.AssertResourceExists(pm.Name, controller.PowerMonitorDeploymentNS, &mainConfigMap)
 	updatedConfigData := mainConfigMap.Data["config.yaml"]
 	assert.Contains(t, updatedConfigData, "format: text", "updated log format should be merged")
 	assert.Contains(t, updatedConfigData, "level: info", "config set inside spec should have precedence over config set in configmap")
 
-	// test expected status
+	// Verify availability
 	pm = f.WaitUntilPowerMonitorCondition("power-monitor", v1alpha1.Available, v1alpha1.ConditionTrue)
 	available, err := k8s.FindCondition(pm.Status.Conditions, v1alpha1.Available)
 	assert.NoError(t, err, "unable to get available condition")

--- a/tests/run-e2e.sh
+++ b/tests/run-e2e.sh
@@ -28,7 +28,6 @@ declare CI_MODE=false
 declare NO_DEPLOY=false
 declare NO_BUILDS=false
 declare SHOW_USAGE=false
-declare ENABLE_VM_TEST=false
 declare LOGS_DIR="tmp/e2e"
 declare OPERATORS_NS="operators"
 declare TEST_TIMEOUT="15m"
@@ -213,7 +212,6 @@ run_e2e() {
 	local ret=0
 	run go test -v -failfast -timeout $TEST_TIMEOUT \
 		./tests/e2e/... "$@" \
-		-enable-vm-test=$ENABLE_VM_TEST \
 		2>&1 | tee "$LOGS_DIR/e2e.log" || ret=1
 
 	# terminate both log_events
@@ -259,10 +257,6 @@ parse_args() {
 			;;
 		--ci)
 			CI_MODE=true
-			shift
-			;;
-		--enable-vm-test)
-			ENABLE_VM_TEST=true
 			shift
 			;;
 		--image-base)
@@ -321,7 +315,6 @@ cmd_help() {
 		⚙️ Options:
 		  -h|--help        show this help
 		  --ci             run in CI mode
-		  --enable-vm-test run tests in vm environment
 		  --no-deploy      do not build and deploy Operator; useful for rerunning tests
 		  --no-builds      skip building operator images; useful when operator image is already
 		                   built and pushed


### PR DESCRIPTION
This commit updates the e2e tests to now make use of additional config maps while setting up config to run fake cpu power meter on VM.