### PR TITLE
ci: ensure only powermonitor tests are executed

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -287,9 +287,10 @@ jobs:
       - uses: ./.github/compute-version
         id: version
 
+      # NOTE: Running only PowerMonitor test
       - name: Run e2e tests
         run: |
-          ./tests/run-e2e.sh e2e --ci --enable-vm-test
+          ./tests/run-e2e.sh e2e --ci --enable-vm-test -- -skip-kepler-tests
         env:
           VERSION: ${{ steps.version.outputs.version }}
 

--- a/tests/e2e/kepler_internal_test.go
+++ b/tests/e2e/kepler_internal_test.go
@@ -23,6 +23,10 @@ import (
 )
 
 func TestKeplerInternal_Reconciliation(t *testing.T) {
+	if skipKeplerTests {
+		t.Skip("Skipping Kepler test")
+	}
+
 	f := test.NewFramework(t)
 	name := "e2e-ki"
 	// test namespace must be the deployment namespace for controller
@@ -55,6 +59,10 @@ func TestKeplerInternal_Reconciliation(t *testing.T) {
 }
 
 func TestKeplerInternal_ReconciliationWithRedfish(t *testing.T) {
+	if skipKeplerTests {
+		t.Skip("Skipping Kepler test")
+	}
+
 	f := test.NewFramework(t)
 	name := "e2e-ki-redfish"
 	secretName := "my-redfish-secret"

--- a/tests/e2e/kepler_test.go
+++ b/tests/e2e/kepler_test.go
@@ -19,6 +19,10 @@ import (
 )
 
 func TestKepler_Deletion(t *testing.T) {
+	if skipKeplerTests {
+		t.Skip("Skipping Kepler test")
+	}
+
 	f := test.NewFramework(t)
 
 	// pre-condition: ensure kepler exists
@@ -42,6 +46,10 @@ func TestKepler_Deletion(t *testing.T) {
 }
 
 func TestKepler_Reconciliation(t *testing.T) {
+	if skipKeplerTests {
+		t.Skip("Skipping Kepler test")
+	}
+
 	f := test.NewFramework(t)
 
 	// pre-condition
@@ -72,6 +80,10 @@ func TestKepler_Reconciliation(t *testing.T) {
 }
 
 func TestBadKepler_Reconciliation(t *testing.T) {
+	if skipKeplerTests {
+		t.Skip("Skipping Kepler test")
+	}
+
 	f := test.NewFramework(t)
 	// Ensure Kepler is not deployed (by any chance)
 	f.AssertNoResourceExists("kepler", "", &v1alpha1.Kepler{}, test.Timeout(10*time.Second))
@@ -82,6 +94,10 @@ func TestBadKepler_Reconciliation(t *testing.T) {
 }
 
 func TestNodeSelector(t *testing.T) {
+	if skipKeplerTests {
+		t.Skip("Skipping Kepler test")
+	}
+
 	f := test.NewFramework(t)
 	// Ensure Kepler is not deployed (by any chance)
 	f.AssertNoResourceExists("kepler", "", &v1alpha1.Kepler{}, test.Timeout(10*time.Second))
@@ -110,6 +126,10 @@ func TestNodeSelector(t *testing.T) {
 }
 
 func TestNodeSelectorUnavailableLabel(t *testing.T) {
+	if skipKeplerTests {
+		t.Skip("Skipping Kepler test")
+	}
+
 	f := test.NewFramework(t)
 	// Ensure Kepler is not deployed (by any chance)
 	f.AssertNoResourceExists("kepler", "", &v1alpha1.Kepler{}, test.Timeout(10*time.Second))
@@ -135,6 +155,10 @@ func TestNodeSelectorUnavailableLabel(t *testing.T) {
 }
 
 func TestTaint_WithToleration(t *testing.T) {
+	if skipKeplerTests {
+		t.Skip("Skipping Kepler test")
+	}
+
 	f := test.NewFramework(t)
 	// Ensure Kepler is not deployed (by any chance)
 	f.AssertNoResourceExists("kepler", "", &v1alpha1.Kepler{}, test.Timeout(10*time.Second))
@@ -168,6 +192,10 @@ func TestTaint_WithToleration(t *testing.T) {
 }
 
 func TestBadTaint_WithToleration(t *testing.T) {
+	if skipKeplerTests {
+		t.Skip("Skipping Kepler test")
+	}
+
 	f := test.NewFramework(t)
 	// Ensure Kepler is not deployed (by any chance)
 	f.AssertNoResourceExists("kepler", "", &v1alpha1.Kepler{}, test.Timeout(10*time.Second))

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -24,6 +24,7 @@ var (
 	testKeplerRebootImage string
 	vmAnnotationKey       string
 	enableVMTest          bool
+	skipKeplerTests       bool
 )
 
 func TestMain(m *testing.M) {
@@ -34,6 +35,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&testKeplerRebootImage, "kepler-reboot-image", keplerRebootImage, "Kepler image to use when running PowerMonitorInternal tests")
 	flag.StringVar(&vmAnnotationKey, "vm-annotation-key", ciTestVMEnvKey, "VM Annotation Key set to enable vm test environment")
 	flag.BoolVar(&enableVMTest, "enable-vm-test", false, "Enable VM test environment")
+	flag.BoolVar(&skipKeplerTests, "skip-kepler-tests", false, "Skip Kepler tests")
 	flag.Parse()
 
 	if *openshift {


### PR DESCRIPTION
This commit ensures that only powermonitor tests are executed in the CI. It introduces `-skip-kepler-tests` flag that when set, skips all kepler tests

