### PR TITLE
chore: enhance OpenShift dashboards

### DIFF
--- a/internal/controller/power_monitor_internal.go
+++ b/internal/controller/power_monitor_internal.go
@@ -219,6 +219,7 @@ func openshiftPowerMonitorNamespacedResources(pmi *v1alpha1.PowerMonitorInternal
 	if oshift.Dashboard.Enabled {
 		res = append(res,
 			powermonitor.NewPowerMonitorInfoDashboard(components.Full),
+			powermonitor.NewPowerMonitorNamespaceInfoDashboard(components.Full),
 		)
 	}
 	return res

--- a/pkg/components/power-monitor/assets/dashboards/power-monitor-namespace-info.json
+++ b/pkg/components/power-monitor/assets/dashboards/power-monitor-namespace-info.json
@@ -1,0 +1,446 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Power Monitor Namespace Info",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 8,
+  "iteration": 1695643949328,
+  "links": [],
+  "liveNow": false,
+  "rows": [
+    {
+      "collapse": false,
+      "height": "100px",
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "fixed",
+                "fixedColor": "dark-blue"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "inspect": false
+              },
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 7,
+            "x": 0,
+            "y": 0
+          },
+          "id": 15,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "8.5.1",
+          "span": 6,
+          "styles": [
+            {
+              "alias": "Namespace",
+              "colors": [],
+              "decimals": 0,
+              "link": true,
+              "linkTargetBlank": false,
+              "pattern": "pod_namespace",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            },
+            {
+              "alias": "Power Consumption",
+              "colors": [],
+              "decimals": 0,
+              "link": true,
+              "linkTargetBlank": false,
+              "pattern": "Value #A",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "topk(10,sum by (pod_namespace)(kepler_pod_cpu_watts{zone=~\"$zone\"}))",
+              "format": "table",
+              "interval": "",
+              "legendFormat": "",
+              "instant": true,
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Top 10 Power Consuming Namespaces (W)",
+          "type": "table"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Current Stats",
+      "titleSize": "h6"
+    },
+    {
+      "collapsed": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "watt"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "hiddenSeries": false,
+          "id": 16,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.5.1",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (zone) (kepler_pod_cpu_watts{container=\"power-monitor\", pod_namespace=~\"$namespace\"})",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total {{zone}} Watts",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Total Power Consumption of Pods in Namespace (W) per Zone",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "W",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "watt"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "hiddenSeries": false,
+          "id": 16,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.5.1",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "kepler_pod_cpu_watts{container=\"power-monitor\", pod_namespace=~\"$namespace\", pod_name=~\"$pod\", zone=\"$zone\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{zone}} - {{pod_name}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Pod Power Consumption (W) By Zone",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "W",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Namespace Usage",
+      "titleSize": "h6"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [
+    "power-monitor-mixin"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(kepler_pod_cpu_watts{container=\"power-monitor\"}, pod_namespace)",
+        "description": "Namespace to choose",
+        "hide": 0,
+        "includeAll": true,
+        "defaultValue": "$__all",
+        "label": "Namespace",
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(kepler_pod_cpu_watts{container=\"power-monitor\"}, pod_namespace)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(kepler_pod_cpu_watts{container=\"power-monitor\",pod_namespace=~\"$namespace\"}, pod_name)",
+        "description": "Pod to choose",
+        "hide": 0,
+        "includeAll": true,
+        "defaultValue": "$__all",
+        "label": "Pod",
+        "multi": true,
+        "name": "pod",
+        "options": [],
+        "query": "label_values(kepler_pod_cpu_watts{container=\"power-monitor\",pod_namespace=~\"$namespace\"}, pod_name)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(kepler_pod_cpu_watts{container=\"power-monitor\"}, zone)",
+        "description": "Zone to choose",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "zone",
+        "options": [],
+        "query": "label_values(kepler_pod_cpu_watts{container=\"power-monitor\"}, zone)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Power Monitor / Namespace Info",
+  "uid": "125cb5f5fdbea19c3067b2b34e897ad5d2b40a52",
+  "version": 4,
+  "weekStart": ""
+}

--- a/pkg/components/power-monitor/assets/dashboards/power-monitor-node-info.json
+++ b/pkg/components/power-monitor/assets/dashboards/power-monitor-node-info.json
@@ -26,326 +26,611 @@
   "iteration": 1695643949328,
   "links": [],
   "liveNow": false,
-  "panels": [
+  "rows": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed",
-            "fixedColor": "dark-blue"
-          },
-          "custom": {
-            "align": "auto",
-            "displayMode": "auto",
-            "inspect": false
-          },
-          "mappings": []
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 7,
-        "x": 0,
-        "y": 0
-      },
-      "id": 15,
-      "options": {
-        "footer": {
-          "fields": "",
-          "reducer": [],
-          "show": false
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "8.5.1",
-      "span": 6,
-      "styles": [
-        {
-          "alias": "Instance",
-          "colors": [],
-          "decimals": 0,
-          "link": true,
-          "linkTargetBlank": false,
-          "pattern": "instance",
-          "thresholds": [],
-          "type": "string",
-          "unit": "short"
-        },
-        {
-          "alias": "Model Name",
-          "colors": [],
-          "decimals": 0,
-          "link": true,
-          "linkTargetBlank": false,
-          "pattern": "model_name",
-          "thresholds": [],
-          "type": "string",
-          "unit": "short"
-        },
-        {
-          "alias": "Vendor ID",
-          "colors": [],
-          "decimals": 0,
-          "link": true,
-          "linkTargetBlank": false,
-          "pattern": "vendor_id",
-          "thresholds": [],
-          "type": "string",
-          "unit": "short"
-        },
-        {
-          "alias": "Cores",
-          "colors": [],
-          "decimals": 0,
-          "link": true,
-          "linkTargetBlank": false,
-          "pattern": "Value #A",
-          "thresholds": [],
-          "type": "string",
-          "unit": "short"
-        }
-      ],
-      "targets": [
+      "collapse": false,
+      "height": "100px",
+      "panels": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "editorMode": "code",
-          "expr": "count(kepler_node_cpu_info{container=~\"power-monitor\"}) by (instance, model_name, vendor_id)",
-          "format": "table",
-          "interval": "",
-          "legendFormat": "",
-          "instant": true,
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "CPU Info",
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "unit": "watt"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 9,
-        "x": 7,
-        "y": 0
-      },
-      "id": 1,
-      "options": {
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "watt"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 9,
+            "x": 7,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "pluginVersion": "8.5.1",
+          "span": 4,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(kepler_node_cpu_watts{container=~\"power-monitor\", instance=~\"$node\", zone=\"$zone\"})",
+              "hide": false,
+              "interval": "",
+              "refId": "A"
+            }
           ],
-          "fields": "",
-          "values": false
-        }
-      },
-      "pluginVersion": "8.5.1",
-      "span": 6,
-      "targets": [
+          "title": "Current Node Power Consumption By Zone",
+          "type": "singlestat",
+          "postfix": "W"
+        },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "editorMode": "code",
-          "expr": "sum(kepler_node_cpu_watts{container=~\"power-monitor\", instance=~\"$node\", zone=\"$zone\"})",
-          "hide": false,
-          "interval": "",
-          "refId": "A"
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "watt"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 9,
+            "x": 7,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "pluginVersion": "8.5.1",
+          "span": 4,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(kepler_node_cpu_active_watts{container=~\"power-monitor\", instance=~\"$node\", zone=\"$zone\"})",
+              "hide": false,
+              "interval": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Current Node Active Power Consumption By Zone",
+          "type": "singlestat",
+          "postfix": "W"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "watt"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 9,
+            "x": 7,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "pluginVersion": "8.5.1",
+          "span": 4,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(kepler_node_cpu_idle_watts{container=~\"power-monitor\", instance=~\"$node\", zone=\"$zone\"})",
+              "hide": false,
+              "interval": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Current Node Idle Power Consumption By Zone",
+          "type": "singlestat",
+          "postfix": "W"
         }
       ],
-      "title": "Current Node Power Consumption (By Zone)",
-      "type": "singlestat",
-      "postfix": "W"
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Current Stats",
+      "titleSize": "h6"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "unit": "watt"
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 36
-      },
-      "hiddenSeries": false,
-      "id": 16,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.5.1",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
+      "collapse": false,
+      "height": "250px",
+      "panels": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "editorMode": "code",
-          "expr": "sum by (zone) (kepler_node_cpu_watts{container=~\"power-monitor\"})",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "Total {{zone}} Watts",
-          "range": true,
-          "refId": "A"
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "fixed",
+                "fixedColor": "dark-blue"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "inspect": false
+              },
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 7,
+            "x": 0,
+            "y": 0
+          },
+          "id": 15,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "8.5.1",
+          "span": 6,
+          "styles": [
+            {
+              "alias": "Node Name",
+              "colors": [],
+              "decimals": 0,
+              "link": true,
+              "linkTargetBlank": false,
+              "pattern": "instance",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            },
+            {
+              "alias": "Model Name",
+              "colors": [],
+              "decimals": 0,
+              "link": true,
+              "linkTargetBlank": false,
+              "pattern": "model_name",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            },
+            {
+              "alias": "Vendor ID",
+              "colors": [],
+              "decimals": 0,
+              "link": true,
+              "linkTargetBlank": false,
+              "pattern": "vendor_id",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            },
+            {
+              "alias": "Cores",
+              "colors": [],
+              "decimals": 0,
+              "link": true,
+              "linkTargetBlank": false,
+              "pattern": "Value #A",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "count(kepler_node_cpu_info{container=~\"power-monitor\"}) by (instance, model_name, vendor_id)",
+              "format": "table",
+              "interval": "",
+              "legendFormat": "",
+              "instant": true,
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "CPU Info",
+          "type": "table"
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Total Power Consumption (W) per Zone",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "W",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "CPU Info",
+      "titleSize": "h6"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "unit": "watt"
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 16
-      },
-      "hiddenSeries": false,
-      "id": 1,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.5.1",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
+      "collapsed": false,
+      "height": "250px",
+      "panels": [
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "editorMode": "code",
-          "expr": "kepler_node_cpu_watts{container=~\"power-monitor\", instance=~\"$node\", zone=\"$zone\"}",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "{{zone}} - {{instance}}",
-          "range": true,
-          "refId": "A"
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "watt"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "hiddenSeries": false,
+          "id": 16,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.5.1",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (zone) (kepler_node_cpu_watts{container=~\"power-monitor\"})",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total {{zone}} Watts",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Total Power Consumption (W) per Zone",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "W",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "watt"
+            },
+            "overrides": []
+          },
+          "fill": 10,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 16
+          },
+          "hiddenSeries": false,
+          "id": 1,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.5.1",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "span": 4,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "kepler_node_cpu_watts{container=~\"power-monitor\", instance=~\"$node\", zone=\"$zone\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{zone}} - {{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Node Power Consumption (W) By Zone",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "watt"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 16
+          },
+          "hiddenSeries": false,
+          "id": 1,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.5.1",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "span": 4,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "kepler_node_cpu_active_watts{container=~\"power-monitor\", instance=~\"$node\", zone=\"$zone\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{zone}} - {{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Node Active Power Consumption (W) By Zone",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "watt"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 16
+          },
+          "hiddenSeries": false,
+          "id": 1,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.5.1",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "span": 4,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "kepler_node_cpu_idle_watts{container=~\"power-monitor\", instance=~\"$node\", zone=\"$zone\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{zone}} - {{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Node Idle Power Consumption (W) By Zone",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph"
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Node Power Consumption (W)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph"
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Node Usage",
+      "titleSize": "h6"
     }
   ],
   "refresh": "",

--- a/pkg/components/power-monitor/deployment.go
+++ b/pkg/components/power-monitor/deployment.go
@@ -32,7 +32,8 @@ const (
 	PowerMonitorDSPort          = 28282
 
 	// Dashboard
-	InfoDashboardName = "power-monitor-node-info"
+	InfoDashboardName          = "power-monitor-node-info"
+	NamespaceInfoDashboardName = "power-monitor-namespace-info"
 
 	SysFSMountPath      = "/host/sys"
 	ProcFSMountPath     = "/host/proc"
@@ -50,6 +51,9 @@ var (
 	}
 	//go:embed assets/dashboards/power-monitor-node-info.json
 	infoDashboardJson string
+
+	//go:embed assets/dashboards/power-monitor-namespace-info.json
+	namespaceInfoDashboardJson string
 )
 
 func NewPowerMonitorDaemonSet(detail components.Detail, pmi *v1alpha1.PowerMonitorInternal) *appsv1.DaemonSet {
@@ -135,6 +139,10 @@ func NewPowerMonitorService(pmi *v1alpha1.PowerMonitorInternal) *corev1.Service 
 			}},
 		},
 	}
+}
+
+func NewPowerMonitorNamespaceInfoDashboard(d components.Detail) *corev1.ConfigMap {
+	return openshiftDashboardConfigMap(d, NamespaceInfoDashboardName, fmt.Sprintf("%s.json", NamespaceInfoDashboardName), namespaceInfoDashboardJson)
 }
 
 func NewPowerMonitorInfoDashboard(d components.Detail) *corev1.ConfigMap {

--- a/pkg/components/power-monitor/deployment_test.go
+++ b/pkg/components/power-monitor/deployment_test.go
@@ -367,6 +367,17 @@ func TestPowerMonitorDashboards(t *testing.T) {
 			cmKey:              fmt.Sprintf("%s.json", InfoDashboardName),
 			scenario:           "info dashboard case",
 		},
+		{
+			createDashboard: NewPowerMonitorNamespaceInfoDashboard,
+			labels: k8s.StringMap{
+				"console.openshift.io/dashboard": "true",
+				"app.kubernetes.io/managed-by":   "kepler-operator",
+			},
+			dashboardName:      NamespaceInfoDashboardName,
+			dashboardNamespace: DashboardNs,
+			cmKey:              fmt.Sprintf("%s.json", NamespaceInfoDashboardName),
+			scenario:           "namespace info dashboard case",
+		},
 	}
 	for _, tc := range tt {
 		tc := tc


### PR DESCRIPTION
This commit enhance the existing OpenShift dashboards. Changes include:
- Redesign the Power Monitor Info dashboard to now show:
  - Current Node Power Consumption By Zone Stat
  - Current Node Active Power Consumption By Zone Stat
  - Current Node Idle Power Consumption By Zone Stat
  - Node Active Power Consumption (W) By Zone Graph
  - Node Idle Power Consumption (W) By Zone Graph
- Introduces a new dashboard to show namespace / pod related information which includes:
  - Top 10 Power Consuming Namespaces (W) Table
  - Total Power Consumption of Pods in Namespace (W) per Zone Graph
  - Pod Power Consumption (W) By Zone Graph