### PR TITLE
chore: update total power consumption panels to filter by zone

### DIFF
--- a/pkg/components/power-monitor/assets/dashboards/power-monitor-namespace-info.json
+++ b/pkg/components/power-monitor/assets/dashboards/power-monitor-namespace-info.json
@@ -18,7 +18,7 @@
       }
     ]
   },
-  "description": "Power Monitor Namespace Info",
+  "description": "Power Monitor Namespace (Pods)",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
@@ -67,7 +67,11 @@
             "showHeader": true
           },
           "pluginVersion": "8.5.1",
-          "span": 6,
+          "span": 12,
+          "sort": {
+            "col": 1,
+            "desc": true
+          },
           "styles": [
             {
               "alias": "Namespace",
@@ -99,7 +103,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "topk(10,sum by (pod_namespace)(kepler_pod_cpu_watts{zone=~\"$zone\"}))",
+              "expr": "topk(10,sum by (pod_namespace,zone)(kepler_pod_cpu_watts{zone=~\"$zone\"}))",
               "format": "table",
               "interval": "",
               "legendFormat": "",
@@ -108,7 +112,7 @@
               "refId": "A"
             }
           ],
-          "title": "Top 10 Power Consuming Namespaces (W)",
+          "title": "Top 10 Power Consuming Namespaces (W) per Zone",
           "type": "table"
         }
       ],
@@ -180,10 +184,10 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum by (zone) (kepler_pod_cpu_watts{container=\"power-monitor\", pod_namespace=~\"$namespace\"})",
+              "expr": "sum by (zone) (kepler_pod_cpu_watts{container=\"power-monitor\", pod_namespace=~\"$namespace\", zone=~\"$zone\"})",
               "hide": false,
               "interval": "",
-              "legendFormat": "Total {{zone}} Watts",
+              "legendFormat": "Zone - {{zone}}",
               "range": true,
               "refId": "A"
             }
@@ -275,7 +279,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "kepler_pod_cpu_watts{container=\"power-monitor\", pod_namespace=~\"$namespace\", pod_name=~\"$pod\", zone=\"$zone\"}",
+              "expr": "kepler_pod_cpu_watts{container=\"power-monitor\", pod_namespace=~\"$namespace\", pod_name=~\"$pod\", zone=~\"$zone\"}",
               "hide": false,
               "interval": "",
               "legendFormat": "{{zone}} - {{pod_name}}",
@@ -317,7 +321,7 @@
       "repeat": null,
       "repeatIteration": null,
       "repeatRowId": null,
-      "showTitle": true,
+      "showTitle": false,
       "title": "Namespace Usage",
       "titleSize": "h6"
     }
@@ -408,7 +412,12 @@
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": {
           "type": "prometheus",
           "uid": "${datasource}"
@@ -416,7 +425,8 @@
         "definition": "label_values(kepler_pod_cpu_watts{container=\"power-monitor\"}, zone)",
         "description": "Zone to choose",
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
+        "defaultValue": "$__all",
         "label": null,
         "multi": false,
         "name": "zone",
@@ -439,7 +449,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Power Monitor / Namespace Info",
+  "title": "Power Monitor / Namespace (Pods)",
   "uid": "125cb5f5fdbea19c3067b2b34e897ad5d2b40a52",
   "version": 4,
   "weekStart": ""

--- a/pkg/components/power-monitor/assets/dashboards/power-monitor-overview.json
+++ b/pkg/components/power-monitor/assets/dashboards/power-monitor-overview.json
@@ -69,7 +69,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(kepler_node_cpu_watts{container=~\"power-monitor\", instance=~\"$node\", zone=\"$zone\"})",
+              "expr": "sum(kepler_node_cpu_watts{container=~\"power-monitor\", instance=~\"$node\", zone=~\"$zone\"})",
               "hide": false,
               "interval": "",
               "refId": "A"
@@ -117,7 +117,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(kepler_node_cpu_active_watts{container=~\"power-monitor\", instance=~\"$node\", zone=\"$zone\"})",
+              "expr": "sum(kepler_node_cpu_active_watts{container=~\"power-monitor\", instance=~\"$node\", zone=~\"$zone\"})",
               "hide": false,
               "interval": "",
               "refId": "A"
@@ -165,7 +165,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(kepler_node_cpu_idle_watts{container=~\"power-monitor\", instance=~\"$node\", zone=\"$zone\"})",
+              "expr": "sum(kepler_node_cpu_idle_watts{container=~\"power-monitor\", instance=~\"$node\", zone=~\"$zone\"})",
               "hide": false,
               "interval": "",
               "refId": "A"
@@ -223,7 +223,7 @@
             "showHeader": true
           },
           "pluginVersion": "8.5.1",
-          "span": 6,
+          "span": 12,
           "styles": [
             {
               "alias": "Node Name",
@@ -358,10 +358,10 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum by (zone) (kepler_node_cpu_watts{container=~\"power-monitor\"})",
+              "expr": "sum by (zone) (kepler_node_cpu_watts{container=~\"power-monitor\", zone=~\"$zone\"})",
               "hide": false,
               "interval": "",
-              "legendFormat": "Total {{zone}} Watts",
+              "legendFormat": "Zone - {{zone}}",
               "range": true,
               "refId": "A"
             }
@@ -454,7 +454,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "kepler_node_cpu_watts{container=~\"power-monitor\", instance=~\"$node\", zone=\"$zone\"}",
+              "expr": "kepler_node_cpu_watts{container=~\"power-monitor\", instance=~\"$node\", zone=~\"$zone\"}",
               "hide": false,
               "interval": "",
               "legendFormat": "{{zone}} - {{instance}}",
@@ -530,7 +530,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "kepler_node_cpu_active_watts{container=~\"power-monitor\", instance=~\"$node\", zone=\"$zone\"}",
+              "expr": "kepler_node_cpu_active_watts{container=~\"power-monitor\", instance=~\"$node\", zone=~\"$zone\"}",
               "hide": false,
               "interval": "",
               "legendFormat": "{{zone}} - {{instance}}",
@@ -606,7 +606,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "kepler_node_cpu_idle_watts{container=~\"power-monitor\", instance=~\"$node\", zone=\"$zone\"}",
+              "expr": "kepler_node_cpu_idle_watts{container=~\"power-monitor\", instance=~\"$node\", zone=~\"$zone\"}",
               "hide": false,
               "interval": "",
               "legendFormat": "{{zone}} - {{instance}}",
@@ -689,7 +689,12 @@
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": {
           "type": "prometheus",
           "uid": "${datasource}"
@@ -697,7 +702,8 @@
         "definition": "label_values(kepler_node_cpu_watts{container=\"power-monitor\"}, zone)",
         "description": "Zone to choose",
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
+        "defaultValue": "$__all",
         "label": null,
         "multi": false,
         "name": "zone",
@@ -720,7 +726,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Power Monitor / Info",
+  "title": "Power Monitor / Overview",
   "uid": "125cb5f5fdbea19c3067b2b34e897ad5d2b40a52",
   "version": 4,
   "weekStart": ""

--- a/pkg/components/power-monitor/deployment.go
+++ b/pkg/components/power-monitor/deployment.go
@@ -32,7 +32,7 @@ const (
 	PowerMonitorDSPort          = 28282
 
 	// Dashboard
-	InfoDashboardName          = "power-monitor-node-info"
+	OverviewDashboardName      = "power-monitor-overview"
 	NamespaceInfoDashboardName = "power-monitor-namespace-info"
 
 	SysFSMountPath      = "/host/sys"
@@ -48,7 +48,7 @@ var (
 	linuxNodeSelector = k8s.StringMap{
 		"kubernetes.io/os": "linux",
 	}
-	//go:embed assets/dashboards/power-monitor-node-info.json
+	//go:embed assets/dashboards/power-monitor-overview.json
 	infoDashboardJson string
 
 	//go:embed assets/dashboards/power-monitor-namespace-info.json
@@ -145,7 +145,7 @@ func NewPowerMonitorNamespaceInfoDashboard(d components.Detail) *corev1.ConfigMa
 }
 
 func NewPowerMonitorInfoDashboard(d components.Detail) *corev1.ConfigMap {
-	return openshiftDashboardConfigMap(d, InfoDashboardName, fmt.Sprintf("%s.json", InfoDashboardName), infoDashboardJson)
+	return openshiftDashboardConfigMap(d, OverviewDashboardName, fmt.Sprintf("%s.json", OverviewDashboardName), infoDashboardJson)
 }
 
 func NewPowerMonitorConfigMap(d components.Detail, pmi *v1alpha1.PowerMonitorInternal, additionalConfigs ...string) *corev1.ConfigMap {

--- a/pkg/components/power-monitor/deployment_test.go
+++ b/pkg/components/power-monitor/deployment_test.go
@@ -361,9 +361,9 @@ func TestPowerMonitorDashboards(t *testing.T) {
 				"console.openshift.io/dashboard": "true",
 				"app.kubernetes.io/managed-by":   "kepler-operator",
 			},
-			dashboardName:      InfoDashboardName,
+			dashboardName:      OverviewDashboardName,
 			dashboardNamespace: DashboardNs,
-			cmKey:              fmt.Sprintf("%s.json", InfoDashboardName),
+			cmKey:              fmt.Sprintf("%s.json", OverviewDashboardName),
 			scenario:           "info dashboard case",
 		},
 		{


### PR DESCRIPTION
This commit updates the total power consumption panels to filter by zones. Now users can select the zones from the dropdown and the panel will filter the data accordingly.
Additional changes include:
- Rename the node-info dashboard to overview
- Introduces `All` option for the zone dropdown
- Disables the `Namespace Usage` row in the namespace info dashboard
- Renames the legend from `Total package-0 Watts` to `Zone - package-0` for better readability