### PR TITLE
chore: use build-manager target for building operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # Build the manager binary
 FROM golang:1.23 AS builder
 
+ARG VERSION
+ARG GIT_COMMIT
+ARG GIT_BRANCH
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -13,7 +17,10 @@ RUN go mod download
 COPY . .
 
 # Build
-RUN make build
+RUN make build-manager \
+  VERSION=${VERSION} \
+  GIT_COMMIT=${GIT_COMMIT} \
+  GIT_BRANCH=${GIT_BRANCH}
 
 FROM quay.io/openshift/origin-cli:4.18 AS origincli
 


### PR DESCRIPTION
This commit adds a new target to the Makefile to build the operator. `make build-manager` will only be responsible for building the operator `make build` will run the dependencies and build the operator.

It also updates the Dockerfile to use the build-manager target and pass on the required arguments to the build-manager.