### PR TITLE
chore: bump up Kepler version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ $(error VERSION cannot be empty)
 endif
 
 KEPLER_VERSION ?=release-0.7.12
-KEPLER_REBOOT_VERSION ?=v0.0.9
+KEPLER_REBOOT_VERSION ?=v0.0.10
 
 # IMG_BASE and KEPLER_IMG_BASE are set to distinguish between Operator-specific images and Kepler-Specific images.
 # IMG_BASE is used for building and pushing operator related images.

--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.17.0
-    createdAt: "2025-06-12T13:21:09Z"
+    createdAt: "2025-06-23T06:44:43Z"
     description: Deploys and Manages Kepler on Kubernetes
     operators.operatorframework.io/builder: operator-sdk-v1.39.1
     operators.operatorframework.io/internal-objects: |-
@@ -291,7 +291,7 @@ spec:
                 - name: RELATED_IMAGE_KEPLER
                   value: quay.io/sustainable_computing_io/kepler:release-0.7.12
                 - name: RELATED_IMAGE_KEPLER_REBOOT
-                  value: quay.io/sustainable_computing_io/kepler-reboot:v0.0.9
+                  value: quay.io/sustainable_computing_io/kepler-reboot:v0.0.10
                 image: quay.io/sustainable_computing_io/kepler-operator:0.17.0
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
@@ -401,7 +401,7 @@ spec:
   relatedImages:
   - image: quay.io/sustainable_computing_io/kepler:release-0.7.12
     name: kepler
-  - image: quay.io/sustainable_computing_io/kepler-reboot:v0.0.9
+  - image: quay.io/sustainable_computing_io/kepler-reboot:v0.0.10
     name: kepler-reboot
   replaces: kepler-operator.v0.16.0
   version: 0.17.0

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -13,7 +13,7 @@ var Config = struct {
 	Image       string
 	Cluster     k8s.Cluster
 }{
-	RebootImage: "quay.io/sustainable_computing_io/kepler-reboot:v0.0.9",
+	RebootImage: "quay.io/sustainable_computing_io/kepler-reboot:v0.0.10",
 	Image:       "",
 	Cluster:     k8s.Kubernetes,
 }

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	keplerImage       = `quay.io/sustainable_computing_io/kepler:release-0.7.12`
-	keplerRebootImage = `quay.io/sustainable_computing_io/kepler-reboot:v0.0.9`
+	keplerRebootImage = `quay.io/sustainable_computing_io/kepler-reboot:v0.0.10`
 )
 
 var (


### PR DESCRIPTION
This commit bumps up the Kepler version to v0.0.10. There are no config changes for Kepler