### PR TITLE
ci: use custom hook for linting PR commits

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -132,8 +132,6 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Python
         uses: actions/setup-python@v3
@@ -144,11 +142,22 @@ jobs:
       - name: Run Pre-commit
         run: pre-commit run --all-files
 
-      - name: Run Commitlint
-        run: |
-          COMMIT_MSG=$(git log -1 --pretty=%B)
-          echo "$COMMIT_MSG" > .git/COMMIT_EDITMSG
-          pre-commit run commitlint --hook-stage commit-msg --commit-msg-file .git/COMMIT_EDITMSG
+  commit-msg-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all the history of PR commits
+
+      - name: Setup Pre-commit
+        run: pip install pre-commit
+
+      - name: Run Pre-commit
+        run: pre-commit run --hook-stage manual pr-commit-lint --all-files
+        env:
+          FROM: ${{ github.event.pull_request.base.sha }}
+          TO: ${{ github.event.pull_request.head.sha }}
 
   test-and-codecov:
     needs: check-changes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,20 @@ default_install_hook_types:
   - pre-commit
   - commit-msg
 repos:
+  # This hook lints commit messages within a specified range, ideal for validating all commits in a PR.
+  # Environment variables $FROM (start of range) and $TO (end of range) are set in PR Checks workflow.
+  - repo: local
+    hooks:
+      - id: pr-commit-lint
+        name: pr-commit-lint
+        stages: [manual]
+        language: node
+        additional_dependencies:
+          - "@commitlint/cli"
+          - "@commitlint/config-conventional"
+        pass_filenames: false
+        entry: bash -c "commitlint --from $FROM --to $TO --verbose"
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:


### PR DESCRIPTION
This commit adds a custom hook for linting PR commits. It takes commit range from the PR and uses commitlint to lint the commits.