### PR TITLE
chore: use log level as info for Kepler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ fresh: ## default target - sets up a k8s cluster with images ready for deploymen
 	@echo -e ' 🔔 Next step see kepler in action:'
 	@echo -e '    ❯   ./tmp/bin/operator-sdk run bundle localhost:5001/kepler-operator-bundle:0.0.0-dev \ '
 	@echo -e '         --install-mode AllNamespaces --namespace operators --skip-tls '
-	@echo -e '    ❯ kubectl apply -f config/samples/kepler.system_v1alpha1_kepler.yaml \n'
+	@echo -e '    ❯ kubectl apply -f config/samples/kepler.system_v1alpha1_powermonitor.yaml \n'
 	@echo -e '        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
 
 

--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
           "spec": {
             "kepler": {
               "config": {
-                "logLevel": "debug"
+                "logLevel": "info"
               }
             }
           }
@@ -47,7 +47,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.18.0
-    createdAt: "2025-06-30T12:21:06Z"
+    createdAt: "2025-07-02T05:54:15Z"
     description: Deploys and Manages Kepler on Kubernetes
     operators.operatorframework.io/builder: operator-sdk-v1.39.1
     operators.operatorframework.io/internal-objects: |-

--- a/config/samples/kepler.system_v1alpha1_powermonitor.yaml
+++ b/config/samples/kepler.system_v1alpha1_powermonitor.yaml
@@ -9,4 +9,4 @@ metadata:
 spec:
   kepler:
     config:
-      logLevel: debug
+      logLevel: info


### PR DESCRIPTION
This commit updates the log level for Kepler to be info instead of debug