### PR TITLE
chore: remove Kepler reboot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,7 @@ ifeq ($(VERSION),)
 $(error VERSION cannot be empty)
 endif
 
-KEPLER_VERSION ?=release-0.7.12
-KEPLER_REBOOT_VERSION ?=v0.0.10
+KEPLER_VERSION ?=v0.10.0
 KUBE_RBAC_PROXY_VERSION ?=v0.19.0
 
 # IMG_BASE and KEPLER_IMG_BASE are set to distinguish between Operator-specific images and Kepler-Specific images.
@@ -52,7 +51,6 @@ KUBE_RBAC_PROXY_VERSION ?=v0.19.0
 # This separation ensures that local development and deployment of operator images do not interfere with Kepler images.
 IMG_BASE ?= quay.io/sustainable_computing_io
 KEPLER_IMG_BASE ?= quay.io/sustainable_computing_io/kepler
-KEPLER_REBOOT_IMG_BASE ?= quay.io/sustainable_computing_io/kepler-reboot
 KUBE_RBAC_PROXY_IMG_BASE ?= quay.io/brancz/kube-rbac-proxy
 
 # OPERATOR_IMG define the image:tag used for the operator
@@ -61,7 +59,6 @@ OPERATOR_IMG ?= $(IMG_BASE)/kepler-operator:$(VERSION)
 ADDITIONAL_TAGS ?=
 
 KEPLER_IMG ?= $(KEPLER_IMG_BASE):$(KEPLER_VERSION)
-KEPLER_REBOOT_IMG ?= $(KEPLER_REBOOT_IMG_BASE):$(KEPLER_REBOOT_VERSION)
 KUBE_RBAC_PROXY_IMG ?= $(KUBE_RBAC_PROXY_IMG_BASE):$(KUBE_RBAC_PROXY_VERSION)
 
 # E2E_TEST_IMG defines the image:tag used for the e2e test image
@@ -200,7 +197,6 @@ RUN_ARGS ?=
 run: install fmt vet ## Run a controller from your host against openshift cluster
 	go run ./cmd/... \
 		--kepler.image=$(KEPLER_IMG) \
-		--kepler-reboot.image=$(KEPLER_REBOOT_IMG) \
 		--kube-rbac-proxy.image=$(KUBE_RBAC_PROXY_IMG) \
 		--zap-devel --zap-log-level=8 \
 		--openshift=$(OPENSHIFT) \
@@ -290,8 +286,7 @@ deploy: install ## Deploy controller to the K8s cluster specified in ~/.kube/con
 	$(KUSTOMIZE) build config/default/k8s | \
 		sed  -e "s|<OPERATOR_IMG>|$(OPERATOR_IMG)|g" \
 		     -e "s|<KEPLER_IMG>|$(KEPLER_IMG)|g" \
-		     -e "s|<KEPLER_REBOOT_IMG>|$(KEPLER_REBOOT_IMG)|g" \
-			 -e "s|<KUBE_RBAC_PROXY_IMG>|$(KUBE_RBAC_PROXY_IMG)|g" \
+		     -e "s|<KUBE_RBAC_PROXY_IMG>|$(KUBE_RBAC_PROXY_IMG)|g" \
 		| tee tmp/deploy.yaml | \
 		kubectl apply --server-side --force-conflicts -f -
 
@@ -385,7 +380,6 @@ VERSION_REPLACED ?=
 bundle: generate manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	OPERATOR_IMG=$(OPERATOR_IMG) \
 	KEPLER_IMG=$(KEPLER_IMG) \
-	KEPLER_REBOOT_IMG=$(KEPLER_REBOOT_IMG) \
 	KUBE_RBAC_PROXY_IMG=$(KUBE_RBAC_PROXY_IMG) \
 	VERSION=$(VERSION) \
 	VERSION_REPLACED=$(VERSION_REPLACED) \

--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.18.0
-    createdAt: "2025-07-04T23:00:06Z"
+    createdAt: "2025-07-09T11:16:03Z"
     description: Deploys and Manages Kepler on Kubernetes
     operators.operatorframework.io/builder: operator-sdk-v1.39.1
     operators.operatorframework.io/internal-objects: |-
@@ -292,16 +292,13 @@ spec:
                 - --deployment-namespace=kepler-operator
                 - --leader-elect
                 - --kepler.image=$(RELATED_IMAGE_KEPLER)
-                - --kepler-reboot.image=$(RELATED_IMAGE_KEPLER_REBOOT)
                 - --kube-rbac-proxy.image=$(RELATED_IMAGE_KUBE_RBAC_PROXY)
                 - --zap-log-level=5
                 command:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_KEPLER
-                  value: quay.io/sustainable_computing_io/kepler:release-0.7.12
-                - name: RELATED_IMAGE_KEPLER_REBOOT
-                  value: quay.io/sustainable_computing_io/kepler-reboot:v0.0.10
+                  value: quay.io/sustainable_computing_io/kepler:v0.10.0
                 - name: RELATED_IMAGE_KUBE_RBAC_PROXY
                   value: quay.io/brancz/kube-rbac-proxy:v0.19.0
                 image: quay.io/sustainable_computing_io/kepler-operator:0.18.0
@@ -411,10 +408,8 @@ spec:
     name: Kepler Operator Contributors
     url: https://sustainable-computing.io/
   relatedImages:
-  - image: quay.io/sustainable_computing_io/kepler:release-0.7.12
+  - image: quay.io/sustainable_computing_io/kepler:v0.10.0
     name: kepler
-  - image: quay.io/sustainable_computing_io/kepler-reboot:v0.0.10
-    name: kepler-reboot
   - image: quay.io/brancz/kube-rbac-proxy:v0.19.0
     name: kube-rbac-proxy
   replaces: kepler-operator.v0.17.0

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -98,8 +98,6 @@ func main() {
 	// NOTE: RELATED_IMAGE_KEPLER can be set as env or flag, flag takes precedence over env
 	keplerImage := os.Getenv("RELATED_IMAGE_KEPLER")
 	flag.StringVar(&controller.Config.Image, "kepler.image", keplerImage, "kepler image")
-	keplerRebootImg := os.Getenv("RELATED_IMAGE_KEPLER_REBOOT")
-	flag.StringVar(&controller.Config.RebootImage, "kepler-reboot.image", keplerRebootImg, "kepler reboot image")
 	kubeRbacProxyImg := os.Getenv("RELATED_IMAGE_KUBE_RBAC_PROXY")
 	flag.StringVar(&controller.Config.KubeRbacProxyImage, "kube-rbac-proxy.image", kubeRbacProxyImg, "kube rbac proxy image")
 

--- a/config/manager/base/manager.yaml
+++ b/config/manager/base/manager.yaml
@@ -71,14 +71,11 @@ spec:
           env:
             - name: RELATED_IMAGE_KEPLER
               value: "<KEPLER_IMG>"
-            - name: RELATED_IMAGE_KEPLER_REBOOT
-              value: "<KEPLER_REBOOT_IMG>"
             - name: RELATED_IMAGE_KUBE_RBAC_PROXY
               value: "<KUBE_RBAC_PROXY_IMG>"
           args:
             - --leader-elect
             - --kepler.image=$(RELATED_IMAGE_KEPLER)
-            - --kepler-reboot.image=$(RELATED_IMAGE_KEPLER_REBOOT)
             - --kube-rbac-proxy.image=$(RELATED_IMAGE_KUBE_RBAC_PROXY)
             - --zap-log-level=5
           image: "<OPERATOR_IMG>"

--- a/hack/bundle.sh
+++ b/hack/bundle.sh
@@ -49,7 +49,6 @@ main() {
 		sed \
 			-e "s|<OPERATOR_IMG>|$OPERATOR_IMG|g" \
 			-e "s|<KEPLER_IMG>|$KEPLER_IMG|g" \
-			-e "s|<KEPLER_REBOOT_IMG>|$KEPLER_REBOOT_IMG|g" \
 			-e "s|<KUBE_RBAC_PROXY_IMG>|$KUBE_RBAC_PROXY_IMG|g" \
 			-e "s|<OLD_BUNDLE_VERSION>|$old_bundle_version|g" |
 		tee tmp/pre-bundle.yaml |

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -10,12 +10,10 @@ import "github.com/sustainable.computing.io/kepler-operator/pkg/utils/k8s"
 
 var Config = struct {
 	KubeRbacProxyImage string
-	RebootImage        string
 	Image              string
 	Cluster            k8s.Cluster
 }{
 	KubeRbacProxyImage: "quay.io/brancz/kube-rbac-proxy:v0.19.0",
-	RebootImage:        "quay.io/sustainable_computing_io/kepler-reboot:v0.0.10",
 	Image:              "",
 	Cluster:            k8s.Kubernetes,
 }

--- a/internal/controller/power_monitor.go
+++ b/internal/controller/power_monitor.go
@@ -262,7 +262,7 @@ func newPowerMonitorInternal(d components.Detail, pm *v1alpha1.PowerMonitor) *v1
 				Deployment: v1alpha1.PowerMonitorInternalKeplerDeploymentSpec{
 					PowerMonitorKeplerDeploymentSpec: pm.Spec.Kepler.Deployment,
 
-					Image:              Config.RebootImage,
+					Image:              Config.Image,
 					KubeRbacProxyImage: Config.KubeRbacProxyImage,
 					Namespace:          PowerMonitorDeploymentNS,
 				},

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -13,15 +13,13 @@ import (
 )
 
 const (
-	keplerImage        = `quay.io/sustainable_computing_io/kepler:release-0.7.12`
-	keplerRebootImage  = `quay.io/sustainable_computing_io/kepler-reboot:v0.0.10`
+	keplerImage        = `quay.io/sustainable_computing_io/kepler:v0.10.0`
 	kubeRbacProxyImage = `quay.io/brancz/kube-rbac-proxy:v0.19.0`
 )
 
 var (
 	Cluster                k8s.Cluster = k8s.Kubernetes
 	testKeplerImage        string
-	testKeplerRebootImage  string
 	testKubeRbacProxyImage string
 	skipKeplerTests        bool
 	runningOnVM            bool
@@ -32,7 +30,6 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&controller.KeplerDeploymentNS, "deployment-namespace", controller.KeplerDeploymentNS,
 		"Namespace where kepler and its components are deployed.")
 	flag.StringVar(&testKeplerImage, "kepler-image", keplerImage, "Kepler image to use when running Internal tests")
-	flag.StringVar(&testKeplerRebootImage, "kepler-reboot-image", keplerRebootImage, "Kepler image to use when running PowerMonitorInternal tests")
 	flag.StringVar(&testKubeRbacProxyImage, "kube-rbac-proxy-image", kubeRbacProxyImage, "Kube Rbac Proxy image to use when running mode rbac tests")
 	flag.BoolVar(&skipKeplerTests, "skip-kepler-tests", false, "Skip Kepler tests")
 	flag.BoolVar(&runningOnVM, "running-on-vm", false, "Enable VM test environment")

--- a/tests/e2e/power_monitor_internal_test.go
+++ b/tests/e2e/power_monitor_internal_test.go
@@ -32,7 +32,7 @@ func TestPowerMonitorInternal_Reconciliation(t *testing.T) {
 		configMapName := "my-custom-config"
 		f.CreatePowerMonitorInternal(name,
 			b.WithNamespace(testNs),
-			b.WithKeplerImage(testKeplerRebootImage),
+			b.WithKeplerImage(testKeplerImage),
 			b.WithKubeRbacProxyImage(testKubeRbacProxyImage),
 			b.WithCluster(Cluster),
 			b.WithAdditionalConfigMaps([]string{configMapName}),
@@ -49,7 +49,7 @@ func TestPowerMonitorInternal_Reconciliation(t *testing.T) {
 	} else {
 		f.CreatePowerMonitorInternal(name,
 			b.WithNamespace(testNs),
-			b.WithKeplerImage(testKeplerRebootImage),
+			b.WithKeplerImage(testKeplerImage),
 			b.WithKubeRbacProxyImage(testKubeRbacProxyImage),
 			b.WithCluster(Cluster),
 			b.WithSecuritySet(
@@ -94,7 +94,7 @@ func TestPowerMonitorInternal_RBAC_Reconciliation(t *testing.T) {
 		configMapName := "my-custom-config"
 		pmi = f.CreatePowerMonitorInternal(name,
 			b.WithNamespace(testNs),
-			b.WithKeplerImage(testKeplerRebootImage),
+			b.WithKeplerImage(testKeplerImage),
 			b.WithKubeRbacProxyImage(testKubeRbacProxyImage),
 			b.WithCluster(Cluster),
 			b.WithAdditionalConfigMaps([]string{configMapName}),
@@ -113,7 +113,7 @@ func TestPowerMonitorInternal_RBAC_Reconciliation(t *testing.T) {
 	} else {
 		pmi = f.CreatePowerMonitorInternal(name,
 			b.WithNamespace(testNs),
-			b.WithKeplerImage(testKeplerRebootImage),
+			b.WithKeplerImage(testKeplerImage),
 			b.WithKubeRbacProxyImage(testKubeRbacProxyImage),
 			b.WithCluster(Cluster),
 			b.WithSecuritySet(

--- a/tests/run-e2e.sh
+++ b/tests/run-e2e.sh
@@ -196,19 +196,10 @@ check_images() {
 	local actual_image=""
 	local expected_image=""
 
-	info "Checking Kepler CR image"
-	actual_image=$(kubectl get keplerinternals -o \
-		jsonpath="{.items[*].spec.exporter.deployment.image}")
-	expected_image=$(yq -r .spec.relatedImages[0].image "$OPERATOR_CSV")
-	[[ "$actual_image" != "$expected_image" ]] && {
-		fail "Kepler images are not up to date: actual: $actual_image != $expected_image"
-		return 1
-	}
-
 	info "Checking PowerMonitor CR image"
 	actual_image=$(kubectl get powermonitorinternals -o \
 		jsonpath="{.items[*].spec.kepler.deployment.image}")
-	expected_image=$(yq -r .spec.relatedImages[1].image "$OPERATOR_CSV")
+	expected_image=$(yq -r .spec.relatedImages[0].image "$OPERATOR_CSV")
 	[[ "$actual_image" != "$expected_image" ]] && {
 		fail "Kepler images are not up to date: actual: $actual_image != $expected_image"
 		return 1


### PR DESCRIPTION
This commit switches Kepler image to use of updated image(Kepler reboot) and removes the `RELATED_IMAGE_KEPLER_REBOOT` from the operator as it is not required anymore.