### PR TITLE
chore: rename MountSecretAnnotationToDaemonset and MountConfigMapToDaemonSet

### DIFF
--- a/pkg/components/power-monitor/deployment_test.go
+++ b/pkg/components/power-monitor/deployment_test.go
@@ -219,7 +219,7 @@ func TestPowerMonitorDaemonSet(t *testing.T) {
 			}
 			ds := NewPowerMonitorDaemonSet(components.Full, &pmi)
 			if tc.addConfigMap {
-				MountConfigMapToDaemonSet(ds, tc.configMap)
+				AnnotateDaemonSetWithConfigMapHash(ds, tc.configMap)
 			}
 
 			actualHostPID := k8s.HostPIDFromDS(ds)
@@ -986,7 +986,7 @@ func TestPowerMonitorUWMTokenSecret(t *testing.T) {
 	}
 }
 
-func TestMountSecretAnnotationToDaemonset(t *testing.T) {
+func TestAnnotateDaemonSetWithSecretHash(t *testing.T) {
 	tt := []struct {
 		secret     *corev1.Secret
 		annotation map[string]string
@@ -1019,7 +1019,7 @@ func TestMountSecretAnnotationToDaemonset(t *testing.T) {
 				},
 			}
 			ds := NewPowerMonitorDaemonSet(components.Full, &pmi)
-			MountSecretAnnotationToDaemonset(ds, tc.secret)
+			AnnotateDaemonSetWithSecretHash(ds, tc.secret)
 			actualAnnotation := k8s.AnnotationFromDS(ds)
 			assert.Equal(t, tc.annotation, actualAnnotation)
 		})

--- a/pkg/reconciler/power-monitor.go
+++ b/pkg/reconciler/power-monitor.go
@@ -32,7 +32,7 @@ func (r PowerMonitorDeployer) Reconcile(ctx context.Context, c client.Client, s 
 	}
 
 	cfm := powermonitor.NewPowerMonitorConfigMap(components.Full, r.Pmi, additionalConfigs...)
-	powermonitor.MountConfigMapToDaemonSet(r.Ds, cfm)
+	powermonitor.AnnotateDaemonSetWithConfigMapHash(r.Ds, cfm)
 
 	// Update the ConfigMap
 	return Updater{Owner: r.Pmi, Resource: cfm}.Reconcile(ctx, c, s)

--- a/pkg/reconciler/security.go
+++ b/pkg/reconciler/security.go
@@ -183,7 +183,7 @@ func (r KubeRBACProxyObjectsChecker) Reconcile(ctx context.Context, c client.Cli
 			Error:  err,
 		}
 	}
-	powermonitor.MountSecretAnnotationToDaemonset(r.Ds, proxyConfig) // rename from Mount to Set
+	powermonitor.AnnotateDaemonSetWithSecretHash(r.Ds, proxyConfig)
 	// check power monitor tls secret
 	var pmTLS *corev1.Secret
 	if err := retryWithTimeout(ctx, timeout, retryDelay, func() error {
@@ -215,7 +215,7 @@ func (r KubeRBACProxyObjectsChecker) Reconcile(ctx context.Context, c client.Cli
 			Error:  err,
 		}
 	}
-	powermonitor.MountSecretAnnotationToDaemonset(r.Ds, pmTLS)
+	powermonitor.AnnotateDaemonSetWithSecretHash(r.Ds, pmTLS)
 
 	if r.EnableUWM {
 		// check ca bundle


### PR DESCRIPTION
Renamed MountConfigMapToDaemonset and MountSecretAnnotationToDaemonset to AnnotateDaemonSetWithConfigMapHash and AnnotateDaemonSetWithSecretHash respectively to remove ambiguity.