### PR TITLE
chore: add example for security setting in PowerMonitor CR

### DIFF
--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -39,6 +39,11 @@ metadata:
             "kepler": {
               "config": {
                 "logLevel": "info"
+              },
+              "deployment": {
+                "security": {
+                  "mode": "none"
+                }
               }
             }
           }

--- a/config/samples/kepler.system_v1alpha1_powermonitor.yaml
+++ b/config/samples/kepler.system_v1alpha1_powermonitor.yaml
@@ -10,3 +10,6 @@ spec:
   kepler:
     config:
       logLevel: info
+    deployment:
+      security:
+        mode: none


### PR DESCRIPTION
This commit updates the PowerMonitor CR example to include security settings with default values