### PR TITLE
chore: add error propagation to deployment.go

### DIFF
--- a/pkg/components/power-monitor/deployment_test.go
+++ b/pkg/components/power-monitor/deployment_test.go
@@ -481,7 +481,11 @@ func TestPowerMonitorConfigMap(t *testing.T) {
 		scenario       string
 	}{
 		{
-			spec: v1alpha1.PowerMonitorInternalKeplerSpec{},
+			spec: v1alpha1.PowerMonitorInternalKeplerSpec{
+				Config: v1alpha1.PowerMonitorInternalKeplerConfigSpec{
+					LogLevel: "info",
+				},
+			},
 			labels: k8s.StringMap{
 				"app.kubernetes.io/component":                "exporter",
 				"operator.sustainable-computing.io/internal": "power-monitor-internal",
@@ -521,7 +525,8 @@ func TestPowerMonitorConfigMap(t *testing.T) {
 					Kepler: tc.spec,
 				},
 			}
-			cm := NewPowerMonitorConfigMap(components.Full, &pmi)
+			cm, err := NewPowerMonitorConfigMap(components.Full, &pmi)
+			assert.NoError(t, err)
 
 			actualLabels := k8s.LabelsFromConfigMap(cm)
 			assert.Equal(t, tc.labels.ToMap(), actualLabels)
@@ -882,11 +887,10 @@ func TestPowerMonitorCABundleConfigMap(t *testing.T) {
 
 func TestPowerMonitorKubeRBACProxyConfig(t *testing.T) {
 	tt := []struct {
-		spec       v1alpha1.PowerMonitorInternalKeplerSpec
-		name       string
-		labels     k8s.StringMap
-		configData map[string]string
-		scenario   string
+		spec     v1alpha1.PowerMonitorInternalKeplerSpec
+		name     string
+		labels   k8s.StringMap
+		scenario string
 	}{
 		{
 			spec: v1alpha1.PowerMonitorInternalKeplerSpec{
@@ -907,9 +911,6 @@ func TestPowerMonitorKubeRBACProxyConfig(t *testing.T) {
 				"app.kubernetes.io/part-of":                  "power-monitor-internal",
 				"app.kubernetes.io/managed-by":               "kepler-operator",
 			},
-			configData: map[string]string{
-				"config.yaml": createKubeRBACConfig([]string{"test-sa"}),
-			},
 			scenario: "rbac case",
 		},
 	}
@@ -926,11 +927,17 @@ func TestPowerMonitorKubeRBACProxyConfig(t *testing.T) {
 					Kepler: tc.spec,
 				},
 			}
-			secret := NewPowerMonitorKubeRBACProxyConfig(components.Full, &pmi)
+			rbacConfig, err := createKubeRBACConfig([]string{"test-sa"})
+			assert.NoError(t, err)
+			configData := map[string]string{
+				"config.yaml": rbacConfig,
+			}
+			secret, err := NewPowerMonitorKubeRBACProxyConfig(components.Full, &pmi)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.name, secret.Name)
 			assert.Equal(t, pmi.Spec.Kepler.Deployment.Namespace, secret.Namespace)
 			assert.Equal(t, tc.labels.ToMap(), secret.Labels)
-			assert.Equal(t, tc.configData, secret.StringData)
+			assert.Equal(t, configData, secret.StringData)
 			assert.Equal(t, corev1.SecretTypeOpaque, secret.Type)
 		})
 	}

--- a/pkg/reconciler/power-monitor.go
+++ b/pkg/reconciler/power-monitor.go
@@ -31,7 +31,10 @@ func (r PowerMonitorDeployer) Reconcile(ctx context.Context, c client.Client, s 
 		return Result{Action: Stop, Error: fmt.Errorf("error creating config: %w", err)}
 	}
 
-	cfm := powermonitor.NewPowerMonitorConfigMap(components.Full, r.Pmi, additionalConfigs...)
+	cfm, err := powermonitor.NewPowerMonitorConfigMap(components.Full, r.Pmi, additionalConfigs...)
+	if err != nil {
+		return Result{Action: Stop, Error: fmt.Errorf("error creating configmap: %w", err)}
+	}
 	powermonitor.AnnotateDaemonSetWithConfigMapHash(r.Ds, cfm)
 
 	// Update the ConfigMap

--- a/pkg/reconciler/security.go
+++ b/pkg/reconciler/security.go
@@ -35,16 +35,20 @@ type KubeRBACProxyConfigReconciler struct {
 
 func (r KubeRBACProxyConfigReconciler) Reconcile(ctx context.Context, c client.Client, s *runtime.Scheme) Result {
 	if !r.EnableRBAC {
-		secretKubeRBACConfig := powermonitor.NewPowerMonitorKubeRBACProxyConfig(
+		// when retrieving KubeRBACProxyConfig Metadata, the error return value is always nil
+		secretKubeRBACConfig, _ := powermonitor.NewPowerMonitorKubeRBACProxyConfig(
 			components.Metadata,
 			r.Pmi,
 		)
 		return Deleter{Resource: secretKubeRBACConfig}.Reconcile(ctx, c, s)
 	}
-	secretKubeRBACConfig := powermonitor.NewPowerMonitorKubeRBACProxyConfig(
+	secretKubeRBACConfig, err := powermonitor.NewPowerMonitorKubeRBACProxyConfig(
 		components.Full,
 		r.Pmi,
 	)
+	if err != nil {
+		return Result{Action: Stop, Error: fmt.Errorf("error creating kube-rbac-proxy configmap: %w", err)}
+	}
 	return Updater{Owner: r.Pmi, Resource: secretKubeRBACConfig}.Reconcile(ctx, c, s)
 }
 


### PR DESCRIPTION
For builders that can return an error  like KeplerConfig and NewPowerMonitorKubeRBACProxyConfig, errors from these functions are now returned to the reconcilers to be handled gracefully.