### PR TITLE
fix: resolve liveness probe failure in RBAC mode

### DIFF
--- a/pkg/components/power-monitor/deployment.go
+++ b/pkg/components/power-monitor/deployment.go
@@ -661,10 +661,11 @@ func newPowerMonitorContainer(pmi *v1alpha1.PowerMonitorInternal) corev1.Contain
 		}},
 		LivenessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/metrics",
-					Port:   intstr.IntOrString{Type: intstr.Int, IntVal: int32(PowerMonitorDSPort)},
-					Scheme: "HTTP",
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"curl", "-f", "-s",
+						fmt.Sprintf("http://%s/metrics", webListenAddress),
+					},
 				},
 			},
 			FailureThreshold:    5,


### PR DESCRIPTION
This commit resolves the issue where the liveness probe fails in RBAC mode by replacing the HTTP GET liveness probe with exec probe.

In case of RBAC mode, container listens on 127.0.0.1:28282 and HTTP GET liveness probe runs from kubelet. Kubelet cannot reach to pod's localhost causing the probe failure.

Exec probe runs inside container and can reach host in both the modes

Addresses: https://github.com/sustainable-computing-io/kepler-operator/pull/566#issuecomment-3067169985