### PR TITLE
test: ensure RBAC e2e can run on OpenShift

### DIFF
--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -26,7 +26,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	openshift := flag.Bool("openshift", true, "Indicate if tests are run aginast an OpenShift cluster.")
+	openshift := flag.Bool("openshift", false, "Indicate if tests are run aginast an OpenShift cluster.")
 	flag.StringVar(&controller.KeplerDeploymentNS, "deployment-namespace", controller.KeplerDeploymentNS,
 		"Namespace where kepler and its components are deployed.")
 	flag.StringVar(&testKeplerImage, "kepler-image", keplerImage, "Kepler image to use when running Internal tests")

--- a/tests/e2e/power_monitor_internal_test.go
+++ b/tests/e2e/power_monitor_internal_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sustainable.computing.io/kepler-operator/api/v1alpha1"
 	"github.com/sustainable.computing.io/kepler-operator/internal/controller"
 	powermonitor "github.com/sustainable.computing.io/kepler-operator/pkg/components/power-monitor"
+	"github.com/sustainable.computing.io/kepler-operator/pkg/utils/k8s"
 	"github.com/sustainable.computing.io/kepler-operator/pkg/utils/test"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -124,40 +125,125 @@ func TestPowerMonitorInternal_RBAC_Reconciliation(t *testing.T) {
 			),
 		)
 	}
-	// then the following resources will be created
-	f.AssertResourceExists(testNs, "", &corev1.Namespace{})
 
-	// generate missing certs required in openshift
-	clusterIssuerName := "selfsigned-cluster-issuer"
-	caCertName := "power-monitor-ca"
-	caCertSecretName := "power-monitor-ca-secret"
-	pmIssuerName := "power-monitor-ca-issuer"
-	tlsCertName := powermonitor.SecretTLSCertName
 	tlsCertSecretName := powermonitor.SecretTLSCertName
-	f.DeployOpenshiftCerts(name, testNs, clusterIssuerName, caCertName, caCertSecretName, pmIssuerName, tlsCertName, tlsCertSecretName)
+	var caCertSource string
+
+	if Cluster == k8s.Kubernetes {
+		// For Kubernetes clusters, deploy cert-manager and dependencies
+		clusterIssuerName := "selfsigned-cluster-issuer"
+		caCertName := "power-monitor-ca"
+		caCertSecretName := "power-monitor-ca-secret"
+		pmIssuerName := "power-monitor-ca-issuer"
+		f.DeployOpenshiftCerts(
+			pmi.Name,
+			testNs,
+			clusterIssuerName,
+			caCertName,
+			caCertSecretName,
+			pmIssuerName,
+			tlsCertSecretName,
+			tlsCertSecretName,
+		)
+		caCertSource = caCertSecretName
+	} else {
+		f.WaitUntilPowerMonitorInternalCondition(pmi.Name, v1alpha1.Reconciled, v1alpha1.ConditionTrue)
+		f.WaitForOpenshiftCerts(pmi.Name, testNs, tlsCertSecretName)
+		caCertSource = tlsCertSecretName
+	}
+
+	// then
+	f.AssertResourceExists(testNs, "", &corev1.Namespace{})
 	ds := appsv1.DaemonSet{}
 	f.AssertResourceExists(pmi.Name, testNs, &ds)
-	containers := ds.Spec.Template.Spec.Containers
-	assert.Equal(t, 2, len(containers))
-	// test expected status (PowerMonitor)
-	f.AssertPowerMonitorInternalStatus(pmi.Name, test.Timeout(5*time.Minute))
-	// wait for reconciliation to be ready
-	time.Sleep(60 * time.Second)
 
-	audience := fmt.Sprintf("%s.%s.svc", name, testNs)
-	serviceURL := fmt.Sprintf("https://%s.%s.svc:%d/metrics", name, testNs, powermonitor.SecurePort)
+	retrievedPmi := f.WaitUntilPowerMonitorInternalCondition(name, v1alpha1.Reconciled, v1alpha1.ConditionTrue)
+	// default toleration
+	assert.Equal(t, []corev1.Toleration{{Operator: "Exists"}}, retrievedPmi.Spec.Kepler.Deployment.Tolerations)
+	reconciled, err := k8s.FindCondition(retrievedPmi.Status.Conditions, v1alpha1.Reconciled)
+	assert.NoError(t, err, "unable to get reconciled condition")
+	assert.Equal(t, reconciled.ObservedGeneration, retrievedPmi.Generation)
+	assert.Equal(t, reconciled.Status, v1alpha1.ConditionTrue)
+
+	retrievedPmi = f.WaitUntilPowerMonitorInternalCondition(name, v1alpha1.Available, v1alpha1.ConditionTrue)
+	available, err := k8s.FindCondition(retrievedPmi.Status.Conditions, v1alpha1.Available)
+	assert.NoError(t, err, "unable to get available condition")
+	assert.Equal(t, available.ObservedGeneration, retrievedPmi.Generation)
+	assert.Equal(t, available.Status, v1alpha1.ConditionTrue)
+
+	audience := fmt.Sprintf("%s.%s.svc", pmi.Name, testNs)
+	serviceURL := fmt.Sprintf(
+		"https://%s.%s.svc:%d/metrics",
+		pmi.Name,
+		testNs,
+		powermonitor.SecurePort,
+	)
+
+	// wait for relevant secrets to be created
+	tlsSecret := corev1.Secret{}
+	f.AssertResourceExists(
+		tlsCertSecretName,
+		testNs,
+		&tlsSecret,
+		test.Timeout(5*time.Minute),
+	)
+	assert.NotEmpty(t, tlsSecret.Data["tls.crt"], "TLS cert should be present")
+	assert.NotEmpty(t, tlsSecret.Data["tls.key"], "TLS key should be present")
 
 	// deploy successful curl job
 	successfulJobName := "successful-test-curl"
 	successfulTestSAName := "successful-test-curl-sa"
 	successfulTestCurlNs := "successful-test-namespace"
-	logs := f.CreateCurlPowerMonitorTestSuite(successfulJobName, successfulTestSAName, successfulTestCurlNs, audience, serviceURL, caCertSecretName, testNs)
-	assert.True(t, strings.Contains(logs, "HTTP/2 200"), fmt.Sprintf("expected %s to successfully access (200) the secure endpoint but it did not", successfulJobName))
+	var jobLogs string
+
+	if Cluster == k8s.Kubernetes {
+		jobLogs = f.CreateCurlPowerMonitorTestSuite(
+			successfulJobName,
+			successfulTestSAName,
+			successfulTestCurlNs,
+			audience,
+			serviceURL,
+			caCertSource,
+			testNs,
+		)
+	} else {
+		jobLogs = f.CreateCurlPowerMonitorTestSuiteForOpenShift(
+			successfulJobName,
+			successfulTestSAName,
+			successfulTestCurlNs,
+			audience,
+			serviceURL,
+			caCertSource,
+			testNs,
+		)
+	}
+	assert.True(t, strings.Contains(jobLogs, "HTTP/2 200"), fmt.Sprintf("expected %s to successfully access (200) the secure endpoint but it did not", successfulJobName))
 
 	// deploy blocked curl job
 	failedJobname := "failed-test-curl"
 	failedTestSAName := "failed-test-curl-sa"
 	failedTestCurlNs := "failed-test-namespace"
-	logs = f.CreateCurlPowerMonitorTestSuite(failedJobname, failedTestSAName, failedTestCurlNs, audience, serviceURL, caCertSecretName, testNs)
-	assert.True(t, strings.Contains(logs, "HTTP/2 403"), fmt.Sprintf("expected %s to receive a forbidden error (403) when attempting to access secure endpoint but did not", failedJobname))
+
+	if Cluster == k8s.Kubernetes {
+		jobLogs = f.CreateCurlPowerMonitorTestSuite(
+			failedJobname,
+			failedTestSAName,
+			failedTestCurlNs,
+			audience,
+			serviceURL,
+			caCertSource,
+			testNs,
+		)
+	} else {
+		jobLogs = f.CreateCurlPowerMonitorTestSuiteForOpenShift(
+			failedJobname,
+			failedTestSAName,
+			failedTestCurlNs,
+			audience,
+			serviceURL,
+			caCertSource,
+			testNs,
+		)
+	}
+	assert.True(t, strings.Contains(jobLogs, "HTTP/2 403"), fmt.Sprintf("expected %s to receive a forbidden error (403) when attempting to access secure endpoint but did not", failedJobname))
 }


### PR DESCRIPTION
This commit updates the e2e test for RBAC ensuring that it can run on OpenShift. Existing e2e tests were specific to Kubernetes hence deploys prerequisites for OpenShift on Kubernetes like cert-manager certs, etc. which are not required when running tests against an OpenShift cluster.

In case of OpenShift, it creates the ConfigMap in `testNs` namespace with the annotation `service.beta.openshift.io/inject-cabundle": "true"` OpenShift automatically detects this annotation and injects the service CA certs leveraging OpenShift's automatic CA injection mechanism.