### PR TITLE
ci: ignore utils from codecov generation

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - pkg/utils/k8s/           # Exclude all utils related to k8s
+  - pkg/utils/test/          # Exclude the test utils directory


### PR DESCRIPTION
This commit ignores certain utils files which are related for e2e tests and not impact actual source code being ignored by codecov when generating the coverage report