### PR TITLE
chore: set deployment-namespace to power-monitor

### DIFF
--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -52,7 +52,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.19.0
-    createdAt: "2025-07-10T13:36:57Z"
+    createdAt: "2025-07-16T10:21:12Z"
     description: Deploys and Manages Kepler on Kubernetes
     operators.operatorframework.io/builder: operator-sdk-v1.39.1
     operators.operatorframework.io/internal-objects: |-
@@ -294,7 +294,7 @@ spec:
               containers:
               - args:
                 - --openshift
-                - --deployment-namespace=kepler-operator
+                - --deployment-namespace=power-monitor
                 - --leader-elect
                 - --kepler.image=$(RELATED_IMAGE_KEPLER)
                 - --kube-rbac-proxy.image=$(RELATED_IMAGE_KUBE_RBAC_PROXY)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -84,10 +84,8 @@ func main() {
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 
-	flag.StringVar(&controller.PowerMonitorDeploymentNS, "power-monitor.deployment-namespace", controller.PowerMonitorDeploymentNS,
+	flag.StringVar(&controller.PowerMonitorDeploymentNS, "deployment-namespace", controller.PowerMonitorDeploymentNS,
 		"Namespace where power monitoring components are deployed.")
-	flag.StringVar(&controller.KeplerDeploymentNS, "deployment-namespace", controller.KeplerDeploymentNS,
-		"Namespace where kepler and its components are deployed.")
 
 	flag.CommandLine.Var(flag.Value(&additionalNamespaces), "watch-namespaces",
 		"Namespaces other than deployment-namespace where kepler-internal may be deployed.")
@@ -169,7 +167,6 @@ func main() {
 		// TODO: add new introduced namespace from KeplerInternal.Spec.Deployment.Namespace
 		NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
 			cacheNs := map[string]cache.Config{
-				controller.KeplerDeploymentNS:       {},
 				controller.PowerMonitorDeploymentNS: {},
 			}
 			if openshift {

--- a/config/manager/overlays/openshift/kustomization.yaml
+++ b/config/manager/overlays/openshift/kustomization.yaml
@@ -14,4 +14,4 @@ patches:
         value: --openshift
       - op: add
         path: /spec/template/spec/containers/0/args/1
-        value: --deployment-namespace=kepler-operator
+        value: --deployment-namespace=power-monitor

--- a/tests/run-e2e.sh
+++ b/tests/run-e2e.sh
@@ -261,6 +261,7 @@ watch_operator_errors() {
 }
 
 # run_e2e takes an optional set of args to be passed to go test
+# TODO: Remove logging events for kepler-operator ns once we remove old Kepler CR e2e tests
 run_e2e() {
 	header "Running e2e tests"
 


### PR DESCRIPTION
This commit sets the deployment-namespace flag to power-monitor when deploying PowerMonitor CR