### PR TITLE
chore: bump up Kepler to v0.10.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ ifeq ($(VERSION),)
 $(error VERSION cannot be empty)
 endif
 
-KEPLER_VERSION ?=v0.10.0
+KEPLER_VERSION ?=v0.10.2
 KUBE_RBAC_PROXY_VERSION ?=v0.19.0
 
 # IMG_BASE and KEPLER_IMG_BASE are set to distinguish between Operator-specific images and Kepler-Specific images.

--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -52,7 +52,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.19.0
-    createdAt: "2025-07-16T10:21:12Z"
+    createdAt: "2025-07-18T02:07:09Z"
     description: Deploys and Manages Kepler on Kubernetes
     operators.operatorframework.io/builder: operator-sdk-v1.39.1
     operators.operatorframework.io/internal-objects: |-
@@ -303,7 +303,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_KEPLER
-                  value: quay.io/sustainable_computing_io/kepler:v0.10.0
+                  value: quay.io/sustainable_computing_io/kepler:v0.10.2
                 - name: RELATED_IMAGE_KUBE_RBAC_PROXY
                   value: quay.io/brancz/kube-rbac-proxy:v0.19.0
                 image: quay.io/sustainable_computing_io/kepler-operator:0.19.0
@@ -413,7 +413,7 @@ spec:
     name: Kepler Operator Contributors
     url: https://sustainable-computing.io/
   relatedImages:
-  - image: quay.io/sustainable_computing_io/kepler:v0.10.0
+  - image: quay.io/sustainable_computing_io/kepler:v0.10.2
     name: kepler
   - image: quay.io/brancz/kube-rbac-proxy:v0.19.0
     name: kube-rbac-proxy

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	keplerImage        = `quay.io/sustainable_computing_io/kepler:v0.10.0`
+	keplerImage        = `quay.io/sustainable_computing_io/kepler:v0.10.2`
 	kubeRbacProxyImage = `quay.io/brancz/kube-rbac-proxy:v0.19.0`
 )
 


### PR DESCRIPTION
This commit bumps up Kepler to v0.10.2

NOTE: There is no new config changes introduced in v0.10.2 release of Kepler