### PR TITLE
chore: track Makefile as part of check changes

### DIFF
--- a/.github/publish-images/action.yaml
+++ b/.github/publish-images/action.yaml
@@ -22,9 +22,9 @@ runs:
   using: composite
   steps:
     - name: Checkout source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - uses: actions/setup-go@main
+    - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
         check-latest: true

--- a/.github/tools-cache/action.yaml
+++ b/.github/tools-cache/action.yaml
@@ -4,7 +4,8 @@ description: Caches development tools
 runs:
   using: composite
   steps:
-    - uses: actions/cache@v3
+    - name: Cache tools
+      uses: actions/cache@v3
       id: tools-cache
       with:
         path: ./tmp/bin

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -9,10 +9,10 @@ jobs:
     outputs:
       changes: ${{ steps.filter.outputs.changes }}
     steps:
-      - name: checkout source
+      - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: filter changes
+      - name: Filter changes
         uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -23,12 +23,15 @@ jobs:
               - 'go.sum'
               - 'tests/go.mod'
               - 'tests/go.sum'
+              - 'Makefile'
   docs:
     runs-on: ubuntu-latest-8-cores
     steps:
-      - uses: actions/checkout@main
+      - name: Checkout source
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-go@main
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
@@ -43,9 +46,11 @@ jobs:
   fmt:
     runs-on: ubuntu-latest-8-cores
     steps:
-      - uses: actions/checkout@main
+      - name: Checkout source
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-go@main
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
@@ -60,9 +65,11 @@ jobs:
     if: needs.check-changes.outputs.changes == 'true'
     runs-on: ubuntu-latest-8-cores
     steps:
-      - uses: actions/checkout@main
+      - name: Checkout source
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-go@main
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
@@ -77,9 +84,11 @@ jobs:
     if: needs.check-changes.outputs.changes == 'true'
     runs-on: ubuntu-latest-8-cores
     steps:
-      - uses: actions/checkout@main
+      - name: Checkout source
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-go@main
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
@@ -96,9 +105,11 @@ jobs:
     if: needs.check-changes.outputs.changes == 'true'
     runs-on: ubuntu-latest-8-cores
     steps:
-      - uses: actions/checkout@main
+      - name: Checkout source
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-go@main
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
@@ -118,9 +129,11 @@ jobs:
 
     runs-on: ubuntu-latest-8-cores
     steps:
-      - name: code checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-go@main
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           cache: false
@@ -137,8 +150,11 @@ jobs:
     if: needs.check-changes.outputs.changes == 'true'
     runs-on: ubuntu-latest-8-cores
     steps:
-      - uses: actions/checkout@main
-      - uses: actions/setup-go@main
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
@@ -152,7 +168,7 @@ jobs:
     runs-on: ubuntu-latest-8-cores
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v3
@@ -190,14 +206,18 @@ jobs:
   bundle:
     runs-on: ubuntu-latest-8-cores
     steps:
-      - uses: actions/checkout@main
-      - uses: actions/setup-go@main
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+
       - name: Install all tools
         uses: ./.github/tools-cache
 
-      - name: bundle
+      - name: Generate bundle
         run: |
           make generate manifests bundle
           git diff --exit-code
@@ -205,15 +225,19 @@ jobs:
   build-images:
     runs-on: ubuntu-latest-16-cores
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@main
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
-      - uses: ./.github/compute-version
+      - name: Compute version
+        uses: ./.github/compute-version
         id: version
 
-      - name: additional image tags
+      - name: Additional image tags
         id: additional_tags
         shell: bash
         run: |
@@ -240,19 +264,20 @@ jobs:
 
     runs-on: ubuntu-latest-16-cores
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout source
+        uses: actions/checkout@v4
         with:
           go-version-file: go.mod
 
       - name: Install Go
-        uses: actions/setup-go@main
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Install all tools
         uses: ./.github/tools-cache
 
-      - name: use kepler action for kind cluster build
+      - name: Use Kepler Action for Kind cluster
         uses: sustainable-computing-io/kepler-action@v0.0.5
         with:
           ebpfprovider: libbpf
@@ -263,7 +288,8 @@ jobs:
       - name: Ensure cluster is able to run OLM bundles
         run: make cluster-prereqs
 
-      - uses: ./.github/compute-version
+      - name: Compute version
+        uses: ./.github/compute-version
         id: version
 
       - name: Run Operator Upgrade
@@ -304,17 +330,17 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Go
-        uses: actions/setup-go@main
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Install all tools
         uses: ./.github/tools-cache
 
-      - name: use kepler action for kind cluster build
+      - name: Use Kepler Action for Kind cluster
         uses: sustainable-computing-io/kepler-action@v0.0.5
         with:
           ebpfprovider: libbpf
@@ -325,7 +351,8 @@ jobs:
       - name: Ensure cluster is able to run OLM bundles
         run: make cluster-prereqs
 
-      - uses: ./.github/compute-version
+      - name: Compute version
+        uses: ./.github/compute-version
         id: version
 
       # NOTE: Running only PowerMonitor test

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -15,23 +15,24 @@ jobs:
     runs-on: ubuntu-latest-8-cores
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-go@main
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           cache: true
 
-      - uses: ./.github/compute-version
+      - name: Compute version
+        uses: ./.github/compute-version
         id: version
 
-      - name: additional tags
+      - name: Additional tags
         id: additional_tags
         shell: bash
         run: |
           echo "result=$(git rev-parse --short HEAD),v1alpha1" >> $GITHUB_OUTPUT
 
-      - name: build and publish images to external registry
+      - name: Build and Publish Images to External registry
         uses: ./.github/publish-images
         with:
           image_registry: ${{ vars.IMG_BASE }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,8 +26,8 @@ jobs:
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - name: Checkout source
+        uses: actions/checkout@v4
 
       - name: Login to Quay
         uses: docker/login-action@v2

--- a/Makefile
+++ b/Makefile
@@ -324,6 +324,7 @@ tools:
 $(TOOLS):
 	./hack/tools.sh $@
 
+.PHONY: mod-tidy
 mod-tidy:
 	@go mod tidy
 	@cd tests && go mod tidy


### PR DESCRIPTION
This commit updates the check-changes job to now also track Makefile ensuring that any changes to the Makefile targets that are used in the workflows are also validated.
This also updates the workflows to now use latest/specific version of GH actions used instead of `main` branch.