### PR TITLE
chore: set OCP version range from OCP 4.17-4.19

### DIFF
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -14,4 +14,4 @@ annotations:
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
 # Annotations for OpenShift version
-  com.redhat.openshift.versions: "v4.16-v4.19"
+  com.redhat.openshift.versions: "v4.17-v4.19"

--- a/hack/bundle.sh
+++ b/hack/bundle.sh
@@ -78,7 +78,7 @@ main() {
 	info "Adding additional metadata annotations"
 	cat <<-EOF >>bundle/metadata/annotations.yaml
 		# Annotations for OpenShift version
-		  com.redhat.openshift.versions: "v4.16-v4.19"
+		  com.redhat.openshift.versions: "v4.17-v4.19"
 	EOF
 
 	run operator-sdk bundle validate ./bundle \


### PR DESCRIPTION
This commit updates the annotations to set the OCP version range from 4.17-4.19