### PR TITLE
test: wait for availability as false before enabling fake cpu meter

### DIFF
--- a/tests/utils/framework.go
+++ b/tests/utils/framework.go
@@ -584,11 +584,11 @@ func (f Framework) CreateTestPowerMonitor(name string, runningOnVM bool, additio
 	// Create the PowerMonitor
 	pm := f.CreatePowerMonitor(name, fns...)
 
-	// Wait for the PowerMonitor to be reconciled
-	_ = f.WaitUntilPowerMonitorCondition(name, v1alpha1.Reconciled, v1alpha1.ConditionFalse)
-
 	// For VM environments, create and patch the additional ConfigMap
 	if runningOnVM {
+		// Wait for the PowerMonitor to be reconciled
+		_ = f.WaitUntilPowerMonitorCondition(name, v1alpha1.Reconciled, v1alpha1.ConditionFalse)
+
 		cfm := f.NewAdditionalConfigMap(configMapName, controller.PowerMonitorDeploymentNS, `dev:
   fake-cpu-meter:
     enabled: true`)
@@ -629,11 +629,11 @@ func (f Framework) CreateTestPowerMonitorInternal(name string, testNs string, ru
 	// Create the PowerMonitorInternal
 	pmi := f.CreatePowerMonitorInternal(name, fns...)
 
-	// Wait for the PowerMonitorInternal to be reconciled
-	_ = f.WaitUntilPowerMonitorInternalCondition(name, v1alpha1.Reconciled, v1alpha1.ConditionFalse)
-
 	// For VM environments, create and patch the additional ConfigMap
 	if runningOnVM {
+		// Wait for the PowerMonitorInternal to be reconciled
+		_ = f.WaitUntilPowerMonitorInternalCondition(name, v1alpha1.Reconciled, v1alpha1.ConditionFalse)
+
 		cfm := f.NewAdditionalConfigMap(configMapName, testNs, `dev:
   fake-cpu-meter:
     enabled: true`)


### PR DESCRIPTION
This commit ensures that tests wait for availability as false before creating additional config map which enables fake cpu meter when running on VM so that tests don't try to create configmap before CR is even created.