### PR TITLE
chore: update deprecated methods

### DIFF
--- a/pkg/utils/k8s/k8s.go
+++ b/pkg/utils/k8s/k8s.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sustainable.computing.io/kepler-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -219,8 +218,8 @@ func VolumeFromSecret(name, secretName string) corev1.Volume {
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName:  secretName,
-				Optional:    pointer.Bool(true),
-				DefaultMode: pointer.Int32(420),
+				Optional:    ptr.To(true),
+				DefaultMode: ptr.To(int32(420)),
 			},
 		},
 	}

--- a/tests/e2e/oc_literal_test.go
+++ b/tests/e2e/oc_literal_test.go
@@ -49,7 +49,7 @@ func writePodSpec(t *testing.T, ns string) string {
 }
 
 func getRandomNsName(t *testing.T) string {
-	rand.Seed(time.Now().UnixNano())
+	rand.New(rand.NewSource(time.Now().UnixNano()))
 	min := 0
 	max := 99999
 	num := rand.Intn(max-min+1) + min


### PR DESCRIPTION
This commit updates the deprecated methods in the codebase.
Addresses: #461