### PR TITLE
chore: remove nodeSelector and nodeAffinity from operator

### DIFF
--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -32,7 +32,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.20.0
-    createdAt: "2025-07-29T08:08:15Z"
+    createdAt: "2025-08-27T13:53:21Z"
     description: Deploys and Manages Kepler on Kubernetes
     operators.operatorframework.io/builder: operator-sdk-v1.39.1
     operators.operatorframework.io/internal-objects: |-
@@ -221,22 +221,6 @@ spec:
                 app.kubernetes.io/instance: controller-manager
                 app.kubernetes.io/part-of: kepler-operator
             spec:
-              affinity:
-                nodeAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    nodeSelectorTerms:
-                    - matchExpressions:
-                      - key: kubernetes.io/arch
-                        operator: In
-                        values:
-                        - amd64
-                        - arm64
-                        - ppc64le
-                        - s390x
-                      - key: kubernetes.io/os
-                        operator: In
-                        values:
-                        - linux
               containers:
               - args:
                 - --openshift

--- a/config/manager/base/manager.yaml
+++ b/config/manager/base/manager.yaml
@@ -36,26 +36,6 @@ spec:
         app.kubernetes.io/component: manager
         app.kubernetes.io/part-of: kepler-operator
     spec:
-      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution.
-      # It is considered best practice to support multiple architectures. You can
-      # build your manager image using the makefile target docker-buildx.
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-                      - arm64
-                      - ppc64le
-                      - s390x
-                  - key: kubernetes.io/os
-                    operator: In
-                    values:
-                      - linux
       securityContext:
         runAsNonRoot: true
         # TODO(user): For common cases that do not require escalating privileges

--- a/config/manifests/bases/kepler-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kepler-operator.clusterserviceversion.yaml
@@ -93,22 +93,6 @@ spec:
                 app.kubernetes.io/instance: controller-manager
                 app.kubernetes.io/part-of: kepler-operator
             spec:
-              affinity:
-                nodeAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    nodeSelectorTerms:
-                    - matchExpressions:
-                      - key: kubernetes.io/arch
-                        operator: In
-                        values:
-                        - amd64
-                        - arm64
-                        - ppc64le
-                        - s390x
-                      - key: kubernetes.io/os
-                        operator: In
-                        values:
-                        - linux
               containers:
               - args:
                 - --health-probe-bind-address=:8081


### PR DESCRIPTION
Removes node constraints from the operator to allow scheduling on any nodes

- Removes nodeAffinity from `config/manager/base/manager.yaml`
- Removes nodeAffinity from bundle CSV manifest
- Removes nodeAffinity from `config/manifests/bases` CSV