### PR TITLE
chore: switch from v1alpha1 to main

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -249,7 +249,7 @@ jobs:
         id: additional_tags
         shell: bash
         run: |
-          echo "result=$(git rev-parse --short HEAD),v1alpha1" >> $GITHUB_OUTPUT
+          echo "result=$(git rev-parse --short HEAD),main" >> $GITHUB_OUTPUT
 
       - name: Install all tools
         uses: ./.github/tools-cache

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -2,7 +2,7 @@ name: Push
 
 on: # yamllint disable-line rule:truthy
   push:
-    branches: [v1alpha1]
+    branches: [main]
 
 jobs:
   test-and-codecov:
@@ -30,7 +30,7 @@ jobs:
         id: additional_tags
         shell: bash
         run: |
-          echo "result=$(git rev-parse --short HEAD),v1alpha1" >> $GITHUB_OUTPUT
+          echo "result=$(git rev-parse --short HEAD),main" >> $GITHUB_OUTPUT
 
       - name: Build and Publish Images to External registry
         uses: ./.github/publish-images

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ kubectl apply -k config/samples/
 You can use the pre-built image from quay.io:
 
 ```sh
-make deploy OPERATOR_IMG=quay.io/sustainable_computing_io/kepler-operator:v1alpha1
+make deploy OPERATOR_IMG=quay.io/sustainable_computing_io/kepler-operator:main
 kubectl apply -k config/samples/
 ```
 
@@ -100,7 +100,7 @@ To completely remove the operator and all related resources:
 
 ## 📚 Developer Documentation
 
-[Developer documentation](https://github.com/sustainable-computing-io/kepler-operator/tree/v1alpha1/docs/developer) is available for those who want to contribute to the codebase or understand its internals.
+[Developer documentation](https://github.com/sustainable-computing-io/kepler-operator/tree/main/docs/developer) is available for those who want to contribute to the codebase or understand its internals.
 
 ## 🤝 Contributing
 

--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -81,8 +81,8 @@ spec:
     MUST be enabled in your cluster.
 
     ### Documentation
-    * [User Documentation](https://github.com/sustainable-computing-io/kepler-operator/blob/v1alpha1/README.md)
-    * [Developer Guide](https://github.com/sustainable-computing-io/kepler-operator/tree/v1alpha1/docs/developer)
+    * [User Documentation](https://github.com/sustainable-computing-io/kepler-operator/blob/main/README.md)
+    * [Developer Guide](https://github.com/sustainable-computing-io/kepler-operator/tree/main/docs/developer)
 
     ### Contributing
     * [Report Bugs](https://github.com/sustainable-computing-io/kepler-operator/issues/new?template=bug_report.md) - Found a bug? Let us know!

--- a/config/manifests/bases/kepler-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kepler-operator.clusterserviceversion.yaml
@@ -54,8 +54,8 @@ spec:
     MUST be enabled in your cluster.
 
     ### Documentation
-    * [User Documentation](https://github.com/sustainable-computing-io/kepler-operator/blob/v1alpha1/README.md)
-    * [Developer Guide](https://github.com/sustainable-computing-io/kepler-operator/tree/v1alpha1/docs/developer)
+    * [User Documentation](https://github.com/sustainable-computing-io/kepler-operator/blob/main/README.md)
+    * [Developer Guide](https://github.com/sustainable-computing-io/kepler-operator/tree/main/docs/developer)
 
     ### Contributing
     * [Report Bugs](https://github.com/sustainable-computing-io/kepler-operator/issues/new?template=bug_report.md) - Found a bug? Let us know!


### PR DESCRIPTION
This commit updates the repo to use the main branch instead of the v1alpha1 branch.