### PR TITLE
fix: remove liveness probe from daemonset

### DIFF
--- a/pkg/components/power-monitor/deployment.go
+++ b/pkg/components/power-monitor/deployment.go
@@ -655,21 +655,6 @@ func newPowerMonitorContainer(pmi *v1alpha1.PowerMonitorInternal) corev1.Contain
 			ContainerPort: int32(PowerMonitorDSPort),
 			Name:          PowerMonitorServicePortName,
 		}},
-		LivenessProbe: &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				Exec: &corev1.ExecAction{
-					Command: []string{
-						"curl", "-f", "-s",
-						fmt.Sprintf("http://%s/metrics", webListenAddress),
-					},
-				},
-			},
-			FailureThreshold:    5,
-			InitialDelaySeconds: 10,
-			PeriodSeconds:       60,
-			SuccessThreshold:    1,
-			TimeoutSeconds:      10,
-		},
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "sysfs", MountPath: SysFSMountPath, ReadOnly: true},
 			{Name: "procfs", MountPath: ProcFSMountPath, ReadOnly: true},

--- a/pkg/components/power-monitor/deployment_test.go
+++ b/pkg/components/power-monitor/deployment_test.go
@@ -109,17 +109,16 @@ func TestPowerMonitorTolerations(t *testing.T) {
 
 func TestPowerMonitorDaemonSet(t *testing.T) {
 	tt := []struct {
-		spec                     v1alpha1.PowerMonitorInternalKeplerSpec
-		hostPID                  bool
-		exporterCommand          []string
-		volumeMounts             []corev1.VolumeMount
-		volumes                  []corev1.Volume
-		containers               []string
-		scenario                 string
-		addConfigMap             bool
-		configMap                *corev1.ConfigMap
-		annotation               map[string]string
-		expectedLivenessProbeURL string
+		spec            v1alpha1.PowerMonitorInternalKeplerSpec
+		hostPID         bool
+		exporterCommand []string
+		volumeMounts    []corev1.VolumeMount
+		volumes         []corev1.Volume
+		containers      []string
+		scenario        string
+		addConfigMap    bool
+		configMap       *corev1.ConfigMap
+		annotation      map[string]string
 	}{
 		{
 			spec:    v1alpha1.PowerMonitorInternalKeplerSpec{},
@@ -141,9 +140,8 @@ func TestPowerMonitorDaemonSet(t *testing.T) {
 				k8s.VolumeFromHost("procfs", "/proc"),
 				k8s.VolumeFromConfigMap("cfm", "power-monitor-internal"),
 			},
-			containers:               []string{"power-monitor-internal"},
-			scenario:                 "default case",
-			expectedLivenessProbeURL: fmt.Sprintf("http://0.0.0.0:%d/metrics", PowerMonitorDSPort),
+			containers: []string{"power-monitor-internal"},
+			scenario:   "default case",
 		},
 		{
 			spec:    v1alpha1.PowerMonitorInternalKeplerSpec{},
@@ -178,8 +176,7 @@ func TestPowerMonitorDaemonSet(t *testing.T) {
 			annotation: map[string]string{
 				ConfigMapHashAnnotation + "-power-monitor-internal": "123",
 			},
-			scenario:                 "configmap case",
-			expectedLivenessProbeURL: fmt.Sprintf("http://0.0.0.0:%d/metrics", PowerMonitorDSPort),
+			scenario: "configmap case",
 		},
 		{
 			spec: v1alpha1.PowerMonitorInternalKeplerSpec{
@@ -211,9 +208,8 @@ func TestPowerMonitorDaemonSet(t *testing.T) {
 				k8s.VolumeFromSecret(SecretTLSCertName, SecretTLSCertName),
 				k8s.VolumeFromSecret(SecretKubeRBACProxyConfigName, SecretKubeRBACProxyConfigName),
 			},
-			containers:               []string{"power-monitor-internal", KubeRBACProxyContainerName},
-			scenario:                 "rbac case",
-			expectedLivenessProbeURL: fmt.Sprintf("http://127.0.0.1:%d/metrics", PowerMonitorDSPort),
+			containers: []string{"power-monitor-internal", KubeRBACProxyContainerName},
+			scenario:   "rbac case",
 		},
 	}
 	for _, tc := range tt {
@@ -252,14 +248,6 @@ func TestPowerMonitorDaemonSet(t *testing.T) {
 				actualAnnotation := k8s.AnnotationFromDS(ds)
 				assert.Contains(t, actualAnnotation, ConfigMapHashAnnotation+"-power-monitor-internal")
 			}
-
-			// Validate liveness probe configuration
-			container := ds.Spec.Template.Spec.Containers[0]
-			assert.NotNil(t, container.LivenessProbe, "liveness probe should be configured")
-
-			expectedCommand := []string{"curl", "-f", "-s", tc.expectedLivenessProbeURL}
-			assert.Equal(t, expectedCommand, container.LivenessProbe.Exec.Command,
-				"liveness probe exec command should use curl with correct URL")
 		})
 	}
 }


### PR DESCRIPTION
This commit removes the liveness probe from the daemonset which fixes the issue of forces Kepler to collect data causing unnecessary overhead and disrupt Kepler's normal collection cycle.