### PR TITLE
chore: bump up Kepler to v0.11.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ ifeq ($(VERSION),)
 $(error VERSION cannot be empty)
 endif
 
-KEPLER_VERSION ?=v0.10.2
+KEPLER_VERSION ?=v0.11.0
 KUBE_RBAC_PROXY_VERSION ?=v0.19.0
 
 # IMG_BASE and KEPLER_IMG_BASE are set to distinguish between Operator-specific images and Kepler-Specific images.

--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -32,7 +32,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.20.0
-    createdAt: "2025-09-10T02:04:37Z"
+    createdAt: "2025-09-15T06:29:32Z"
     description: Deploys and Manages Kepler on Kubernetes
     operators.operatorframework.io/builder: operator-sdk-v1.39.1
     operators.operatorframework.io/internal-objects: |-
@@ -233,7 +233,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_KEPLER
-                  value: quay.io/sustainable_computing_io/kepler:v0.10.2
+                  value: quay.io/sustainable_computing_io/kepler:v0.11.0
                 - name: RELATED_IMAGE_KUBE_RBAC_PROXY
                   value: quay.io/brancz/kube-rbac-proxy:v0.19.0
                 image: quay.io/sustainable_computing_io/kepler-operator:0.20.0
@@ -343,7 +343,7 @@ spec:
     name: Kepler Operator Contributors
     url: https://sustainable-computing.io/
   relatedImages:
-  - image: quay.io/sustainable_computing_io/kepler:v0.10.2
+  - image: quay.io/sustainable_computing_io/kepler:v0.11.0
     name: kepler
   - image: quay.io/brancz/kube-rbac-proxy:v0.19.0
     name: kube-rbac-proxy

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,7 +14,25 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"gopkg.in/yaml.v3"
+
 	"k8s.io/utils/ptr"
+)
+
+// Feature represents an experimental feature identifier
+type Feature string
+
+const (
+	// ExperimentalRedfishFeature represents the Redfish BMC power monitoring feature
+	ExperimentalRedfishFeature Feature = "redfish"
+
+	// PrometheusFeature represents the Prometheus exporter feature
+	PrometheusFeature Feature = "prometheus"
+
+	// StdoutFeature represents the stdout exporter feature
+	StdoutFeature Feature = "stdout"
+
+	// PprofFeature represents the pprof debug endpoints feature
+	PprofFeature Feature = "pprof"
 )
 
 // Config represents the complete application configuration
@@ -93,6 +111,24 @@ type (
 		Node    string `yaml:"nodeName"`
 	}
 
+	// Platform contains settings for platform power monitoring
+	Platform struct {
+		Redfish Redfish `yaml:"redfish"`
+	}
+
+	// Redfish contains settings for Redfish BMC power monitoring
+	Redfish struct {
+		Enabled     *bool         `yaml:"enabled"`
+		NodeName    string        `yaml:"nodeName"`
+		ConfigFile  string        `yaml:"configFile"`
+		HTTPTimeout time.Duration `yaml:"httpTimeout"` // HTTP client timeout for BMC requests
+	}
+
+	// Experimental contains experimental features (no stability guarantees)
+	Experimental struct {
+		Platform Platform `yaml:"platform"`
+	}
+
 	Config struct {
 		Log      Log      `yaml:"log"`
 		Host     Host     `yaml:"host"`
@@ -102,8 +138,12 @@ type (
 		Web      Web      `yaml:"web"`
 		Debug    Debug    `yaml:"debug"`
 		Dev      Dev      `yaml:"dev"` // WARN: do not expose dev settings as flags
+		Kube     Kube     `yaml:"kube"`
 
-		Kube Kube `yaml:"kube"`
+		// NOTE: Experimental field is a pointer on purpose to
+		// use omitempty to suppress printing (String) Experimental configuration
+		// when it is empty
+		Experimental *Experimental `yaml:"experimental,omitempty"`
 	}
 )
 
@@ -149,8 +189,8 @@ func (m *MetricsLevelValue) IsCumulative() bool {
 type SkipValidation int
 
 const (
-	SkipHostValidation SkipValidation = 1
-	SkipKubeValidation SkipValidation = 2
+	SkipHostValidation         SkipValidation = 1
+	SkipExperimentalValidation SkipValidation = 2
 )
 
 const (
@@ -185,6 +225,11 @@ const (
 	KubernetesFlag   = "kube.enable"
 	KubeConfigFlag   = "kube.config"
 	KubeNodeNameFlag = "kube.node-name"
+
+	// Experimental Platform flags
+	ExperimentalPlatformRedfishEnabledFlag  = "experimental.platform.redfish.enabled"
+	ExperimentalPlatformRedfishNodeNameFlag = "experimental.platform.redfish.node-name"
+	ExperimentalPlatformRedfishConfigFlag   = "experimental.platform.redfish.config-file"
 
 // WARN:  dev settings shouldn't be exposed as flags as flags are intended for end users
 )
@@ -231,6 +276,10 @@ func DefaultConfig() *Config {
 		Kube: Kube{
 			Enabled: ptr.To(false),
 		},
+
+		// NOTE: Experimental config will be nil by default and only allocated when needed
+		// to avoid printing the configs if experimental features are disabled
+		// see use of `omitempty`
 	}
 
 	cfg.Dev.FakeCpuMeter.Enabled = ptr.To(false)
@@ -327,6 +376,11 @@ func RegisterFlags(app *kingpin.Application) ConfigUpdaterFn {
 	kubeconfig := app.Flag(KubeConfigFlag, "Path to a kubeconfig. Only required if out-of-cluster.").ExistingFile()
 	nodeName := app.Flag(KubeNodeNameFlag, "Name of kubernetes node on which kepler is running.").String()
 
+	// experimental platform
+	redfishEnabled := app.Flag(ExperimentalPlatformRedfishEnabledFlag, "Enable experimental Redfish BMC power monitoring").Default("false").Bool()
+	redfishNodeName := app.Flag(ExperimentalPlatformRedfishNodeNameFlag, "Node name for experimental Redfish platform power monitoring").String()
+	redfishConfig := app.Flag(ExperimentalPlatformRedfishConfigFlag, "Path to experimental Redfish BMC configuration file").String()
+
 	return func(cfg *Config) error {
 		// Logging settings
 		if flagsSet[LogLevelFlag] {
@@ -389,9 +443,144 @@ func RegisterFlags(app *kingpin.Application) ConfigUpdaterFn {
 			cfg.Kube.Node = *nodeName
 		}
 
+		// Apply experimental platform settings
+		if err := applyRedfishConfig(cfg, flagsSet, redfishEnabled, redfishNodeName, redfishConfig); err != nil {
+			return err
+		}
+
 		cfg.sanitize()
 		return cfg.Validate()
 	}
+}
+
+// applyRedfishConfig applies Redfish configuration flags and resolves NodeName if enabled
+func applyRedfishConfig(cfg *Config, flagsSet map[string]bool, enabled *bool, nodeName *string, cfgFile *string) error {
+	// Early exit if no redfish flags are set and config file does not have experimental
+	// section (i.e cfg.Experimental == nil)
+	if !hasRedfishFlags(flagsSet) && cfg.Experimental == nil {
+		return nil
+	}
+
+	// At this point, either redfish flags are set or config file has experimental section
+	// so ensure experimental section exists
+	if cfg.Experimental == nil {
+		cfg.Experimental = &Experimental{
+			Platform: Platform{
+				Redfish: defaultRedfishConfig(),
+			},
+		}
+	}
+
+	redfish := &cfg.Experimental.Platform.Redfish
+
+	// Apply flag values
+	applyRedfishFlags(redfish, flagsSet, enabled, nodeName, cfgFile)
+
+	// Exit (without resolving NodeName) if Redfish is not enabled
+	if !ptr.Deref(redfish.Enabled, false) {
+		return nil
+	}
+
+	// Resolve NodeName since Redfish is enabled
+	return resolveRedfishNodeName(redfish, cfg.Kube.Node)
+}
+
+// hasRedfishFlags returns true if any experimental flags are set
+func hasRedfishFlags(flagsSet map[string]bool) bool {
+	return flagsSet[ExperimentalPlatformRedfishEnabledFlag] ||
+		flagsSet[ExperimentalPlatformRedfishNodeNameFlag] ||
+		flagsSet[ExperimentalPlatformRedfishConfigFlag]
+}
+
+func defaultRedfishConfig() Redfish {
+	return Redfish{
+		Enabled:     ptr.To(false),
+		HTTPTimeout: 5 * time.Second,
+	}
+}
+
+// applyRedfishFlags applies flag values to redfish config
+func applyRedfishFlags(redfish *Redfish, flagsSet map[string]bool, enabled *bool, nodeName *string, cfgFile *string) {
+	if flagsSet[ExperimentalPlatformRedfishEnabledFlag] {
+		redfish.Enabled = enabled
+	}
+
+	if flagsSet[ExperimentalPlatformRedfishNodeNameFlag] {
+		redfish.NodeName = *nodeName
+	}
+
+	if flagsSet[ExperimentalPlatformRedfishConfigFlag] {
+		redfish.ConfigFile = *cfgFile
+	}
+}
+
+// resolveRedfishNodeName resolves the Redfish node name
+func resolveRedfishNodeName(redfish *Redfish, kubeNodeName string) error {
+	resolvedNodeName, err := resolveNodeName(redfish.NodeName, kubeNodeName)
+	if err != nil {
+		return fmt.Errorf("failed to resolve Redfish node name: %w", err)
+	}
+	redfish.NodeName = resolvedNodeName
+	return nil
+}
+
+// resolveNodeName resolves the node name using the following precedence:
+// 1. CLI flag / config.yaml (--experimental.platform.redfish.node-name)
+// 2. Kubernetes node name
+// 3. Hostname fallback
+func resolveNodeName(redfishNodeName, kubeNodeName string) (string, error) {
+	// Priority 1: CLI flag
+	if strings.TrimSpace(redfishNodeName) != "" {
+		return strings.TrimSpace(redfishNodeName), nil
+	}
+
+	// Priority 2: Kubernetes node name
+	if strings.TrimSpace(kubeNodeName) != "" {
+		return strings.TrimSpace(kubeNodeName), nil
+	}
+
+	// Priority 3: Hostname fallback
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine node name: %w", err)
+	}
+
+	return hostname, nil
+}
+
+// IsFeatureEnabled returns true if the specified feature is enabled
+func (c *Config) IsFeatureEnabled(feature Feature) bool {
+	switch feature {
+	case ExperimentalRedfishFeature:
+		if c.Experimental == nil {
+			return false
+		}
+		return ptr.Deref(c.Experimental.Platform.Redfish.Enabled, false)
+	case PrometheusFeature:
+		return ptr.Deref(c.Exporter.Prometheus.Enabled, false)
+	case StdoutFeature:
+		return ptr.Deref(c.Exporter.Stdout.Enabled, false)
+	case PprofFeature:
+		return ptr.Deref(c.Debug.Pprof.Enabled, false)
+	default:
+		return false
+	}
+}
+
+// experimentalFeatureEnabled returns true if any experimental feature is enabled
+func (c *Config) experimentalFeatureEnabled() bool {
+	if c.Experimental == nil {
+		return false
+	}
+
+	// Check if Redfish is enabled
+	if ptr.Deref(c.Experimental.Platform.Redfish.Enabled, false) {
+		return true
+	}
+
+	// Add checks for future experimental features here
+
+	return false
 }
 
 func (c *Config) sanitize() {
@@ -412,6 +601,18 @@ func (c *Config) sanitize() {
 		c.Exporter.Prometheus.DebugCollectors[i] = strings.TrimSpace(c.Exporter.Prometheus.DebugCollectors[i])
 	}
 	c.Kube.Config = strings.TrimSpace(c.Kube.Config)
+
+	if c.Experimental == nil {
+		return
+	}
+
+	c.Experimental.Platform.Redfish.NodeName = strings.TrimSpace(c.Experimental.Platform.Redfish.NodeName)
+	c.Experimental.Platform.Redfish.ConfigFile = strings.TrimSpace(c.Experimental.Platform.Redfish.ConfigFile)
+
+	// If all experimental features are disabled, set experimental to nil to hide it
+	if !c.experimentalFeatureEnabled() {
+		c.Experimental = nil
+	}
 }
 
 // Validate checks for configuration errors
@@ -500,12 +701,39 @@ func (c *Config) Validate(skips ...SkipValidation) error {
 			}
 		}
 	}
+	// Experimental Platform validation
+	if experimentalErrs := c.validateExperimentalConfig(validationSkipped); len(experimentalErrs) > 0 {
+		errs = append(errs, experimentalErrs...)
+	}
 
 	if len(errs) > 0 {
 		return fmt.Errorf("invalid configuration: %s", strings.Join(errs, ", "))
 	}
 
 	return nil
+}
+
+// validateExperimentalConfig validates experimental configuration settings
+func (c *Config) validateExperimentalConfig(validationSkipped map[SkipValidation]bool) []string {
+	if !c.experimentalFeatureEnabled() || validationSkipped[SkipExperimentalValidation] {
+		return nil
+	}
+
+	var errs []string
+
+	{ // Validate experimental settings
+		if c.IsFeatureEnabled(ExperimentalRedfishFeature) {
+			if c.Experimental.Platform.Redfish.ConfigFile == "" {
+				errs = append(errs, fmt.Sprintf("%s not supplied but %s set to true", ExperimentalPlatformRedfishConfigFlag, ExperimentalPlatformRedfishEnabledFlag))
+			} else {
+				if err := canReadFile(c.Experimental.Platform.Redfish.ConfigFile); err != nil {
+					errs = append(errs, fmt.Sprintf("unreadable Redfish config file: %s: %s", c.Experimental.Platform.Redfish.ConfigFile, err.Error()))
+				}
+			}
+		}
+	}
+
+	return errs
 }
 
 func canReadDir(path string) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -590,6 +590,21 @@ func TestValidateWithSkip(t *testing.T) {
 	// Validate with skipping host validation
 	err := cfg.Validate(SkipHostValidation)
 	assert.NoError(t, err, "Should pass when SkipHostValidation is provided")
+
+	// Create a config with invalid experimental config
+	cfg = DefaultConfig()
+	cfg.Experimental = &Experimental{
+		Platform: Platform{
+			Redfish: Redfish{
+				Enabled:    ptr.To(true),
+				ConfigFile: "/path/invalid",
+			},
+		},
+	}
+
+	// Validate with skipping experimental validation
+	err = cfg.Validate(SkipExperimentalValidation)
+	assert.NoError(t, err, "Should pass when SkipExperimentalValidation is provided")
 }
 
 func TestMonitorConfig(t *testing.T) {
@@ -1880,6 +1895,497 @@ func TestValidatePort(t *testing.T) {
 				}
 			} else {
 				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Redfish-related tests for improved coverage
+
+func TestDefaultRedfishConfig(t *testing.T) {
+	redfish := defaultRedfishConfig()
+	assert.Equal(t, ptr.To(false), redfish.Enabled)
+	assert.Equal(t, 5*time.Second, redfish.HTTPTimeout)
+}
+
+func TestApplyRedfishFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		redfish  *Redfish
+		flagsSet map[string]bool
+		enabled  *bool
+		nodeName *string
+		cfgFile  *string
+		expected *Redfish
+	}{{
+		name:     "no flags set",
+		redfish:  &Redfish{},
+		flagsSet: map[string]bool{},
+		enabled:  ptr.To(true),
+		nodeName: ptr.To("test-node"),
+		cfgFile:  ptr.To("/test/config.yaml"),
+		expected: &Redfish{},
+	}, {
+		name:    "enabled flag set",
+		redfish: &Redfish{},
+		flagsSet: map[string]bool{
+			ExperimentalPlatformRedfishEnabledFlag: true,
+		},
+		enabled:  ptr.To(true),
+		nodeName: ptr.To("test-node"),
+		cfgFile:  ptr.To("/test/config.yaml"),
+		expected: &Redfish{
+			Enabled: ptr.To(true),
+		},
+	}, {
+		name:    "nodename flag set",
+		redfish: &Redfish{},
+		flagsSet: map[string]bool{
+			ExperimentalPlatformRedfishNodeNameFlag: true,
+		},
+		enabled:  ptr.To(true),
+		nodeName: ptr.To("test-node"),
+		cfgFile:  ptr.To("/test/config.yaml"),
+		expected: &Redfish{
+			NodeName: "test-node",
+		},
+	}, {
+		name:    "config flag set",
+		redfish: &Redfish{},
+		flagsSet: map[string]bool{
+			ExperimentalPlatformRedfishConfigFlag: true,
+		},
+		enabled:  ptr.To(true),
+		nodeName: ptr.To("test-node"),
+		cfgFile:  ptr.To("/test/config.yaml"),
+		expected: &Redfish{
+			ConfigFile: "/test/config.yaml",
+		},
+	}, {
+		name:    "all flags set",
+		redfish: &Redfish{},
+		flagsSet: map[string]bool{
+			ExperimentalPlatformRedfishEnabledFlag:  true,
+			ExperimentalPlatformRedfishNodeNameFlag: true,
+			ExperimentalPlatformRedfishConfigFlag:   true,
+		},
+		enabled:  ptr.To(true),
+		nodeName: ptr.To("test-node"),
+		cfgFile:  ptr.To("/test/config.yaml"),
+		expected: &Redfish{
+			Enabled:    ptr.To(true),
+			NodeName:   "test-node",
+			ConfigFile: "/test/config.yaml",
+		},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			applyRedfishFlags(tc.redfish, tc.flagsSet, tc.enabled, tc.nodeName, tc.cfgFile)
+			assert.Equal(t, tc.expected, tc.redfish)
+		})
+	}
+}
+
+func TestHasRedfishFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		flagsSet map[string]bool
+		expected bool
+	}{{
+		name:     "no redfish flags",
+		flagsSet: map[string]bool{},
+		expected: false,
+	}, {
+		name: "has enabled flag",
+		flagsSet: map[string]bool{
+			ExperimentalPlatformRedfishEnabledFlag: true,
+		},
+		expected: true,
+	}, {
+		name: "has nodename flag",
+		flagsSet: map[string]bool{
+			ExperimentalPlatformRedfishNodeNameFlag: true,
+		},
+		expected: true,
+	}, {
+		name: "has config flag",
+		flagsSet: map[string]bool{
+			ExperimentalPlatformRedfishConfigFlag: true,
+		},
+		expected: true,
+	}, {
+		name: "has multiple redfish flags",
+		flagsSet: map[string]bool{
+			ExperimentalPlatformRedfishEnabledFlag:  true,
+			ExperimentalPlatformRedfishNodeNameFlag: true,
+		},
+		expected: true,
+	}, {
+		name: "has non-redfish flags only",
+		flagsSet: map[string]bool{
+			"some.other.flag": true,
+		},
+		expected: false,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := hasRedfishFlags(tc.flagsSet)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestResolveNodeName(t *testing.T) {
+	tests := []struct {
+		name            string
+		redfishNodeName string
+		kubeNodeName    string
+		expectError     bool
+		errorContains   string
+	}{{
+		name:            "redfish node name provided",
+		redfishNodeName: "redfish-node",
+		kubeNodeName:    "kube-node",
+		expectError:     false,
+	}, {
+		name:            "redfish node name with whitespace",
+		redfishNodeName: "  redfish-node  ",
+		kubeNodeName:    "kube-node",
+		expectError:     false,
+	}, {
+		name:            "kube node name fallback",
+		redfishNodeName: "",
+		kubeNodeName:    "kube-node",
+		expectError:     false,
+	}, {
+		name:            "kube node name with whitespace",
+		redfishNodeName: "",
+		kubeNodeName:    "  kube-node  ",
+		expectError:     false,
+	}, {
+		name:            "hostname fallback",
+		redfishNodeName: "",
+		kubeNodeName:    "",
+		expectError:     false,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := resolveNodeName(tc.redfishNodeName, tc.kubeNodeName)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				if tc.errorContains != "" {
+					assert.Contains(t, err.Error(), tc.errorContains)
+				}
+				return
+			}
+
+			assert.NoError(t, err)
+			if tc.redfishNodeName != "" {
+				assert.Equal(t, strings.TrimSpace(tc.redfishNodeName), result)
+			} else if tc.kubeNodeName != "" {
+				assert.Equal(t, strings.TrimSpace(tc.kubeNodeName), result)
+			} else {
+				// Should be hostname
+				assert.NotEmpty(t, result)
+			}
+		})
+	}
+}
+
+func TestResolveRedfishNodeName(t *testing.T) {
+	tests := []struct {
+		name         string
+		redfish      *Redfish
+		kubeNodeName string
+		expectError  bool
+	}{{
+		name: "successful resolution",
+		redfish: &Redfish{
+			NodeName: "test-node",
+		},
+		kubeNodeName: "kube-node",
+		expectError:  false,
+	}, {
+		name: "fallback to kube node name",
+		redfish: &Redfish{
+			NodeName: "",
+		},
+		kubeNodeName: "kube-node",
+		expectError:  false,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := resolveRedfishNodeName(tc.redfish, tc.kubeNodeName)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotEmpty(t, tc.redfish.NodeName)
+		})
+	}
+}
+
+func TestIsFeatureEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *Config
+		feature  Feature
+		expected bool
+	}{{
+		name: "redfish feature enabled",
+		config: &Config{
+			Experimental: &Experimental{
+				Platform: Platform{
+					Redfish: Redfish{
+						Enabled: ptr.To(true),
+					},
+				},
+			},
+		},
+		feature:  ExperimentalRedfishFeature,
+		expected: true,
+	}, {
+		name: "redfish feature disabled",
+		config: &Config{
+			Experimental: &Experimental{
+				Platform: Platform{
+					Redfish: Redfish{
+						Enabled: ptr.To(false),
+					},
+				},
+			},
+		},
+		feature:  ExperimentalRedfishFeature,
+		expected: false,
+	}, {
+		name:     "redfish feature nil experimental",
+		config:   &Config{},
+		feature:  ExperimentalRedfishFeature,
+		expected: false,
+	}, {
+		name: "prometheus feature enabled",
+		config: &Config{
+			Exporter: Exporter{
+				Prometheus: PrometheusExporter{
+					Enabled: ptr.To(true),
+				},
+			},
+		},
+		feature:  PrometheusFeature,
+		expected: true,
+	}, {
+		name: "stdout feature enabled",
+		config: &Config{
+			Exporter: Exporter{
+				Stdout: StdoutExporter{
+					Enabled: ptr.To(true),
+				},
+			},
+		},
+		feature:  StdoutFeature,
+		expected: true,
+	}, {
+		name: "pprof feature enabled",
+		config: &Config{
+			Debug: Debug{
+				Pprof: PprofDebug{
+					Enabled: ptr.To(true),
+				},
+			},
+		},
+		feature:  PprofFeature,
+		expected: true,
+	}, {
+		name:     "unknown feature",
+		config:   &Config{},
+		feature:  Feature("unknown"),
+		expected: false,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.config.IsFeatureEnabled(tc.feature)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestApplyRedfishConfig(t *testing.T) {
+	// Create a temporary config file for testing
+	tmpFile, err := os.CreateTemp("", "redfish-config-*.yaml")
+	assert.NoError(t, err)
+	defer func() {
+		_ = os.Remove(tmpFile.Name())
+	}()
+
+	// Write some dummy config content to make it a valid file
+	_, err = tmpFile.WriteString("# dummy redfish config\nendpoint: https://redfish.example.com\n")
+	assert.NoError(t, err)
+	assert.NoError(t, tmpFile.Close())
+
+	tests := []struct {
+		name        string
+		cfg         *Config
+		flagsSet    map[string]bool
+		enabled     *bool
+		nodeName    *string
+		cfgFile     *string
+		expectError bool
+	}{{
+		name:     "no redfish flags and no experimental config",
+		cfg:      &Config{},
+		flagsSet: map[string]bool{},
+		enabled:  ptr.To(false),
+		nodeName: ptr.To("test-node"),
+		cfgFile:  ptr.To(tmpFile.Name()),
+	}, {
+		name: "has redfish flags",
+		cfg:  &Config{},
+		flagsSet: map[string]bool{
+			ExperimentalPlatformRedfishEnabledFlag: true,
+		},
+		enabled:  ptr.To(true),
+		nodeName: ptr.To("test-node"),
+		cfgFile:  ptr.To(tmpFile.Name()),
+	}, {
+		name: "experimental config exists",
+		cfg: &Config{
+			Experimental: &Experimental{
+				Platform: Platform{
+					Redfish: Redfish{
+						Enabled: ptr.To(false),
+					},
+				},
+			},
+		},
+		flagsSet: map[string]bool{},
+		enabled:  ptr.To(false),
+		nodeName: ptr.To("test-node"),
+		cfgFile:  ptr.To(tmpFile.Name()),
+	}, {
+		name: "redfish enabled with valid config",
+		cfg:  &Config{},
+		flagsSet: map[string]bool{
+			ExperimentalPlatformRedfishEnabledFlag: true,
+			ExperimentalPlatformRedfishConfigFlag:  true,
+		},
+		enabled:  ptr.To(true),
+		nodeName: ptr.To("test-node"),
+		cfgFile:  ptr.To(tmpFile.Name()),
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := applyRedfishConfig(tc.cfg, tc.flagsSet, tc.enabled, tc.nodeName, tc.cfgFile)
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateExperimentalConfig(t *testing.T) {
+	// Create a temporary config file for testing
+	tmpFile, err := os.CreateTemp("", "redfish-config-*.yaml")
+	assert.NoError(t, err)
+	defer func() {
+		_ = os.Remove(tmpFile.Name())
+	}()
+
+	// Write some dummy config content to make it a valid file
+	_, err = tmpFile.WriteString("# dummy redfish config\nendpoint: https://redfish.example.com\n")
+	assert.NoError(t, err)
+	assert.NoError(t, tmpFile.Close())
+
+	tests := []struct {
+		name           string
+		config         *Config
+		expectedErrors []string
+	}{{
+		name:           "no experimental config",
+		config:         &Config{},
+		expectedErrors: nil,
+	}, {
+		name: "redfish disabled",
+		config: &Config{
+			Experimental: &Experimental{
+				Platform: Platform{
+					Redfish: Redfish{
+						Enabled: ptr.To(false),
+					},
+				},
+			},
+		},
+		expectedErrors: nil,
+	}, {
+		name: "redfish enabled without config file",
+		config: &Config{
+			Experimental: &Experimental{
+				Platform: Platform{
+					Redfish: Redfish{
+						Enabled:    ptr.To(true),
+						ConfigFile: "",
+					},
+				},
+			},
+		},
+		expectedErrors: []string{ExperimentalPlatformRedfishConfigFlag + " not supplied"},
+	}, {
+		name: "redfish enabled with valid config file",
+		config: &Config{
+			Experimental: &Experimental{
+				Platform: Platform{
+					Redfish: Redfish{
+						Enabled:    ptr.To(true),
+						ConfigFile: tmpFile.Name(),
+					},
+				},
+			},
+		},
+		expectedErrors: nil,
+	}, {
+		name: "redfish enabled with invalid config file",
+		config: &Config{
+			Experimental: &Experimental{
+				Platform: Platform{
+					Redfish: Redfish{
+						Enabled:    ptr.To(true),
+						ConfigFile: "/non/existent/file.yaml",
+					},
+				},
+			},
+		},
+		expectedErrors: []string{"unreadable Redfish config file"},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errors := tc.config.validateExperimentalConfig(nil)
+
+			if tc.expectedErrors == nil {
+				assert.Empty(t, errors)
+				return
+			}
+			assert.NotEmpty(t, errors)
+			for _, expectedErr := range tc.expectedErrors {
+				found := false
+				for _, actualErr := range errors {
+					if strings.Contains(actualErr, expectedErr) {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "Expected error containing '%s' not found in: %v", expectedErr, errors)
 			}
 		})
 	}

--- a/internal/config/redfish/config.go
+++ b/internal/config/redfish/config.go
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package redfish
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// BMCConfig represents the configuration structure for BMC connections
+type BMCConfig struct {
+	Nodes map[string]string    `yaml:"nodes"` // Node name -> BMC ID mapping
+	BMCs  map[string]BMCDetail `yaml:"bmcs"`  // BMC ID -> BMC connection details
+}
+
+// BMCDetail contains the connection details for a specific BMC
+type BMCDetail struct {
+	Endpoint string `yaml:"endpoint"` // BMC endpoint URL
+	Username string `yaml:"username"` // BMC username
+	Password string `yaml:"password"` // BMC password
+	Insecure bool   `yaml:"insecure"` // Skip TLS verification
+}
+
+// Load loads and parses the BMC configuration file
+func Load(configPath string) (*BMCConfig, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read BMC config file %s: %w", configPath, err)
+	}
+
+	var config BMCConfig
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse BMC config file %s: %w", configPath, err)
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid BMC configuration: %w", err)
+	}
+
+	return &config, nil
+}
+
+// Validate validates the BMC configuration
+func (c *BMCConfig) Validate() error {
+	if len(c.Nodes) == 0 {
+		return fmt.Errorf("no nodes configured")
+	}
+
+	if len(c.BMCs) == 0 {
+		return fmt.Errorf("no BMCs configured")
+	}
+
+	// Validate that all node mappings point to valid BMCs
+	for node, bmcID := range c.Nodes {
+		if _, exists := c.BMCs[bmcID]; !exists {
+			return fmt.Errorf("node %s references non-existent BMC %s", node, bmcID)
+		}
+	}
+
+	// Validate BMC configurations
+	for bmcID, bmc := range c.BMCs {
+		if err := bmc.Validate(); err != nil {
+			return fmt.Errorf("BMC %s configuration invalid: %w", bmcID, err)
+		}
+	}
+
+	return nil
+}
+
+// Validate validates a BMC detail configuration
+func (b *BMCDetail) Validate() error {
+	if strings.TrimSpace(b.Endpoint) == "" {
+		return fmt.Errorf("endpoint is required")
+	}
+
+	// Validate credentials - if one is provided, both must be provided
+	hasUsername := strings.TrimSpace(b.Username) != ""
+	hasPassword := strings.TrimSpace(b.Password) != ""
+
+	if hasUsername && !hasPassword {
+		return fmt.Errorf("password is required when username is provided")
+	}
+
+	if !hasUsername && hasPassword {
+		return fmt.Errorf("username is required when password is provided")
+	}
+
+	return nil
+}
+
+// BMCForNode returns the BMC details for a given node name
+func (c *BMCConfig) BMCForNode(nodeName string) (*BMCDetail, error) {
+	bmcID, exists := c.Nodes[nodeName]
+	if !exists {
+		return nil, fmt.Errorf("node %s not found in BMC configuration", nodeName)
+	}
+
+	bmc, exists := c.BMCs[bmcID]
+	if !exists {
+		return nil, fmt.Errorf("BMC %s not found in BMC configuration", bmcID)
+	}
+
+	return &bmc, nil
+}
+
+// BMCIDForNode returns the BMC ID for a given node name
+func (c *BMCConfig) BMCIDForNode(nodeName string) (string, error) {
+	bmcID, exists := c.Nodes[nodeName]
+	if !exists {
+		return "", fmt.Errorf("node %s not found in BMC configuration", nodeName)
+	}
+
+	_, exists = c.BMCs[bmcID]
+	if !exists {
+		return "", fmt.Errorf("BMC %s not found in BMC configuration", bmcID)
+	}
+
+	return bmcID, nil
+}

--- a/internal/config/redfish/config_test.go
+++ b/internal/config/redfish/config_test.go
@@ -1,0 +1,264 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package redfish
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadAndValidate(t *testing.T) {
+	tt := []struct {
+		name          string
+		configContent string
+		expectError   bool
+		errorContains string
+	}{{
+		name: "Valid configuration",
+		configContent: `
+nodes:
+  node1: bmc1
+  node2: bmc2
+bmcs:
+  bmc1:
+    endpoint: "https://bmc1.example.com"
+    username: "admin"
+    password: "secret"
+  bmc2:
+    endpoint: "https://bmc2.example.com"
+    insecure: true
+`,
+		expectError: false,
+	}, {
+		name: "No credentials",
+		configContent: `
+nodes:
+  node1: bmc1
+bmcs:
+  bmc1:
+    endpoint: "https://bmc1.example.com"
+`,
+		expectError: false,
+	}, {
+		name: "Username without password",
+		configContent: `
+nodes:
+  node1: bmc1
+bmcs:
+  bmc1:
+    endpoint: "https://bmc1.example.com"
+    username: "admin"
+`,
+		expectError:   true,
+		errorContains: "password is required when username is provided",
+	}, {
+		name: "Password without username",
+		configContent: `
+nodes:
+  node1: bmc1
+bmcs:
+  bmc1:
+    endpoint: "https://bmc1.example.com"
+    password: "secret"
+`,
+		expectError:   true,
+		errorContains: "username is required when password is provided",
+	}, {
+		name: "Missing endpoint",
+		configContent: `
+nodes:
+  node1: bmc1
+bmcs:
+  bmc1:
+    username: "admin"
+    password: "secret"
+`,
+		expectError:   true,
+		errorContains: "endpoint is required",
+	}, {
+		name: "Node references non-existent BMC",
+		configContent: `
+nodes:
+  node1: bmc1
+  node2: nonexistent
+bmcs:
+  bmc1:
+    endpoint: "https://bmc1.example.com"
+`,
+		expectError:   true,
+		errorContains: "node node2 references non-existent BMC nonexistent",
+	}, {
+		name: "No nodes configured",
+		configContent: `
+bmcs:
+  bmc1:
+    endpoint: "https://bmc1.example.com"
+`,
+		expectError:   true,
+		errorContains: "no nodes configured",
+	}, {
+		name: "No BMCs configured",
+		configContent: `
+nodes:
+  node1: bmc1
+`,
+		expectError:   true,
+		errorContains: "no BMCs configured",
+	}}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "config_test")
+			require.NoError(t, err)
+			defer func() { _ = os.RemoveAll(tmpDir) }()
+
+			configFile := filepath.Join(tmpDir, "config.yaml")
+			err = os.WriteFile(configFile, []byte(tc.configContent), 0644)
+			require.NoError(t, err)
+
+			config, err := Load(configFile)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				if tc.errorContains != "" {
+					assert.Contains(t, err.Error(), tc.errorContains)
+				}
+				assert.Nil(t, config)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, config)
+			}
+		})
+	}
+}
+
+func TestBMCIDForNodeSuccess(t *testing.T) {
+	// Create temporary config file
+	tmpDir, err := os.MkdirTemp("", "config_test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	configContent := `
+nodes:
+  node1: bmc1
+  node2: bmc2
+bmcs:
+  bmc1:
+    endpoint: "https://bmc1.example.com"
+  bmc2:
+    endpoint: "https://bmc2.example.com"
+`
+
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	err = os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	config, err := Load(configFile)
+	require.NoError(t, err)
+
+	tt := []struct {
+		name     string
+		nodeName string
+		expected string
+		wantErr  bool
+	}{{
+		name:     "Valid node1",
+		nodeName: "node1",
+		expected: "bmc1",
+		wantErr:  false,
+	}, {
+		name:     "Valid node2",
+		nodeName: "node2",
+		expected: "bmc2",
+		wantErr:  false,
+	}, {
+		name:     "Non-existent node",
+		nodeName: "node3",
+		wantErr:  true,
+	}, {
+		name:     "Empty node ID",
+		nodeName: "",
+		wantErr:  true,
+	}}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := config.BMCIDForNode(tc.nodeName)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestBMCForNodeEdgeCases(t *testing.T) {
+	// Create temporary config with edge cases
+	tmpDir, err := os.MkdirTemp("", "config_edge_test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	configContent := `
+nodes:
+  node1: bmc1
+  node2: nonexistent-bmc  # BMC that doesn't exist in bmcs section
+bmcs:
+  bmc1:
+    endpoint: "https://bmc1.example.com"
+    username: "admin"
+    password: "secret"
+    insecure: true
+`
+
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	err = os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	_, err = Load(configFile)
+	require.Error(t, err) // Should fail validation due to nonexistent-bmc
+
+	// Test manually created config for edge cases
+	config := &BMCConfig{
+		Nodes: map[string]string{
+			"node1": "bmc1",
+		},
+		BMCs: map[string]BMCDetail{
+			"bmc1": {
+				Endpoint: "https://bmc1.example.com",
+				Username: "admin",
+				Password: "secret",
+				Insecure: true,
+			},
+		},
+	}
+
+	tt := []struct {
+		name     string
+		nodeName string
+		wantErr  bool
+	}{{
+		name:     "Valid node",
+		nodeName: "node1",
+		wantErr:  false,
+	}}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := config.BMCForNode(tc.nodeName)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/components/power-monitor/deployment.go
+++ b/pkg/components/power-monitor/deployment.go
@@ -798,7 +798,8 @@ func KeplerConfig(pmi *v1alpha1.PowerMonitorInternal, additionalConfigs ...strin
 		cfg.Monitor.MaxTerminated = 500
 	}
 
-	if err := cfg.Validate(config.SkipHostValidation); err != nil {
+	// Skip validation of paths and files that only exist in the target Kepler pods, not in the operator container.
+	if err := cfg.Validate(config.SkipHostValidation, config.SkipExperimentalValidation); err != nil {
 		return config.DefaultConfig().String(), err
 	}
 	return cfg.String(), nil

--- a/pkg/components/power-monitor/deployment_test.go
+++ b/pkg/components/power-monitor/deployment_test.go
@@ -1366,6 +1366,31 @@ func TestKeplerConfig(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, defaultConfig.String(), configStr)
 	})
+
+	t.Run("With config validation error", func(t *testing.T) {
+		pmi := &v1alpha1.PowerMonitorInternal{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "power-monitor-internal",
+			},
+			Spec: v1alpha1.PowerMonitorInternalSpec{
+				Kepler: v1alpha1.PowerMonitorInternalKeplerSpec{
+					Config: v1alpha1.PowerMonitorInternalKeplerConfigSpec{
+						LogLevel: "info",
+					},
+				},
+			},
+		}
+
+		invalidConfig := `log:
+  format: invalid_format` // Invalid log format causes validation error
+
+		configStr, err := KeplerConfig(pmi, invalidConfig)
+
+		expectedConfig := config.DefaultConfig().String()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid log format")
+		assert.Equal(t, expectedConfig, configStr)
+	})
 }
 
 func TestPowerMonitorServiceMonitor(t *testing.T) {

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	keplerImage        = `quay.io/sustainable_computing_io/kepler:v0.10.2`
+	keplerImage        = `quay.io/sustainable_computing_io/kepler:v0.11.0`
 	kubeRbacProxyImage = `quay.io/brancz/kube-rbac-proxy:v0.19.0`
 )
 


### PR DESCRIPTION
This commit bumps up Kepler to v0.11.0.

Changes include:

- Bumping up Kepler to v0.11.0
- Move the latest config to internal/config/
- Skip validating external redfish config for controller manager