### PR TITLE
chore: bump up OCP versions

### DIFF
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -13,5 +13,5 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
-# Annotations for OpenShift version
-  com.redhat.openshift.versions: "v4.17-v4.19"
+  # Annotations for OpenShift version
+  com.redhat.openshift.versions: "v4.18-v4.20"

--- a/hack/bundle.sh
+++ b/hack/bundle.sh
@@ -77,8 +77,8 @@ main() {
 
 	info "Adding additional metadata annotations"
 	cat <<-EOF >>bundle/metadata/annotations.yaml
-		# Annotations for OpenShift version
-		  com.redhat.openshift.versions: "v4.17-v4.19"
+		  # Annotations for OpenShift version
+		  com.redhat.openshift.versions: "v4.18-v4.20"
 	EOF
 
 	run operator-sdk bundle validate ./bundle \


### PR DESCRIPTION
This commit bump up supported OCP version for kepler-operator to v4.18-v4.20