### PR TITLE
fix: remove security mode from samples

### DIFF
--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -19,11 +19,6 @@ metadata:
             "kepler": {
               "config": {
                 "logLevel": "info"
-              },
-              "deployment": {
-                "security": {
-                  "mode": "none"
-                }
               }
             }
           }
@@ -32,7 +27,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.22.3
-    createdAt: "2025-10-08T12:22:16Z"
+    createdAt: "2025-10-09T13:54:51Z"
     description: Deploys and Manages Kepler on Kubernetes
     operators.operatorframework.io/builder: operator-sdk-v1.39.1
     operators.operatorframework.io/internal-objects: |-

--- a/config/samples/kepler.system_v1alpha1_powermonitor.yaml
+++ b/config/samples/kepler.system_v1alpha1_powermonitor.yaml
@@ -10,9 +10,7 @@ spec:
   kepler:
     config:
       logLevel: info
-    deployment:
-      security:
-        mode: none
+    # deployment:
       # secrets:
       #   - name: my-tls-secret
       #     mountPath: /etc/kepler/secrets/tls

--- a/tests/run-e2e.sh
+++ b/tests/run-e2e.sh
@@ -163,7 +163,8 @@ create_power_monitor() {
 		"$POWERMONITOR_RELEASED_CR"
 
 	info "Setting the Security mode as none for tests"
-	yq eval -i '.spec.kepler.deployment.security.mode = "none"' "$POWERMONITOR_RELEASED_CR"
+	yq eval -i '.spec.kepler.deployment.security.mode = "none"' \
+		"$POWERMONITOR_RELEASED_CR"
 
 	cat "$POWERMONITOR_RELEASED_CR"
 


### PR DESCRIPTION
This commit removes the security mode from the samples. The security mode was set to none by default and when the operator was deployed using default spec on OpenShift it was deployed with the security mode set to none. Ideally we shouldn't have set this in samples so that the operator can be deployed with the default security mode i.e rbac