### PR TITLE
chore: disable terminated workload tracking

### DIFF
--- a/api/v1alpha1/power_monitor_internal_types.go
+++ b/api/v1alpha1/power_monitor_internal_types.go
@@ -69,7 +69,7 @@ type PowerMonitorInternalKeplerConfigSpec struct {
 	// Zero: disable terminated workload tracking completely
 	// Positive values: track top N terminated workloads by energy consumption
 	// +optional
-	// +kubebuilder:default=500
+	// +kubebuilder:default=0
 	MaxTerminated *int32 `json:"maxTerminated,omitempty"`
 }
 

--- a/api/v1alpha1/power_monitor_types.go
+++ b/api/v1alpha1/power_monitor_types.go
@@ -93,7 +93,7 @@ type PowerMonitorKeplerConfigSpec struct {
 	// Zero: disable terminated workload tracking completely
 	// Positive values: track top N terminated workloads by energy consumption
 	// +optional
-	// +kubebuilder:default=500
+	// +kubebuilder:default=0
 	MaxTerminated *int32 `json:"maxTerminated,omitempty"`
 }
 

--- a/bundle/manifests/kepler.system.sustainable.computing.io_powermonitorinternals.yaml
+++ b/bundle/manifests/kepler.system.sustainable.computing.io_powermonitorinternals.yaml
@@ -94,7 +94,7 @@ spec:
                         default: info
                         type: string
                       maxTerminated:
-                        default: 500
+                        default: 0
                         description: |-
                           MaxTerminated controls terminated workload tracking behavior
                           Negative values: track unlimited terminated workloads (no capacity limit)

--- a/bundle/manifests/kepler.system.sustainable.computing.io_powermonitors.yaml
+++ b/bundle/manifests/kepler.system.sustainable.computing.io_powermonitors.yaml
@@ -100,7 +100,7 @@ spec:
                         default: info
                         type: string
                       maxTerminated:
-                        default: 500
+                        default: 0
                         description: |-
                           MaxTerminated controls terminated workload tracking behavior
                           Negative values: track unlimited terminated workloads (no capacity limit)

--- a/config/crd/bases/kepler.system.sustainable.computing.io_powermonitorinternals.yaml
+++ b/config/crd/bases/kepler.system.sustainable.computing.io_powermonitorinternals.yaml
@@ -94,7 +94,7 @@ spec:
                         default: info
                         type: string
                       maxTerminated:
-                        default: 500
+                        default: 0
                         description: |-
                           MaxTerminated controls terminated workload tracking behavior
                           Negative values: track unlimited terminated workloads (no capacity limit)

--- a/config/crd/bases/kepler.system.sustainable.computing.io_powermonitors.yaml
+++ b/config/crd/bases/kepler.system.sustainable.computing.io_powermonitors.yaml
@@ -90,7 +90,7 @@ spec:
                         default: info
                         type: string
                       maxTerminated:
-                        default: 500
+                        default: 0
                         description: |-
                           MaxTerminated controls terminated workload tracking behavior
                           Negative values: track unlimited terminated workloads (no capacity limit)

--- a/docs/api.md
+++ b/docs/api.md
@@ -413,7 +413,7 @@ Zero: disable terminated workload tracking completely
 Positive values: track top N terminated workloads by energy consumption<br/>
           <br/>
             <i>Format</i>: int32<br/>
-            <i>Default</i>: 500<br/>
+            <i>Default</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -893,7 +893,7 @@ Zero: disable terminated workload tracking completely
 Positive values: track top N terminated workloads by energy consumption<br/>
           <br/>
             <i>Format</i>: int32<br/>
-            <i>Default</i>: 500<br/>
+            <i>Default</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/manifests/helm/kepler-operator/crds/kepler.system.sustainable.computing.io_powermonitorinternals.yaml
+++ b/manifests/helm/kepler-operator/crds/kepler.system.sustainable.computing.io_powermonitorinternals.yaml
@@ -94,7 +94,7 @@ spec:
                         default: info
                         type: string
                       maxTerminated:
-                        default: 500
+                        default: 0
                         description: |-
                           MaxTerminated controls terminated workload tracking behavior
                           Negative values: track unlimited terminated workloads (no capacity limit)

--- a/manifests/helm/kepler-operator/crds/kepler.system.sustainable.computing.io_powermonitors.yaml
+++ b/manifests/helm/kepler-operator/crds/kepler.system.sustainable.computing.io_powermonitors.yaml
@@ -90,7 +90,7 @@ spec:
                         default: info
                         type: string
                       maxTerminated:
-                        default: 500
+                        default: 0
                         description: |-
                           MaxTerminated controls terminated workload tracking behavior
                           Negative values: track unlimited terminated workloads (no capacity limit)


### PR DESCRIPTION
This commit disables the terminated workload tracking by setting `maxTerminated` to 0