### PR TITLE
ci: remove unused property from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,6 @@ updates:
     ignore:
       - dependency-name: k8s.io/*
         update-types: [version-update:semver-major, version-update:semver-minor]
-    commit-message:
-      include: scope
     open-pull-requests-limit: 5
     labels:
       - dependencies
@@ -32,8 +30,6 @@ updates:
     ignore:
       - dependency-name: k8s.io/*
         update-types: [version-update:semver-major, version-update:semver-minor]
-    commit-message:
-      include: scope
     open-pull-requests-limit: 5
     labels:
       - dependencies
@@ -48,8 +44,6 @@ updates:
       github-actions:
         patterns:
           - "*"
-    commit-message:
-      include: scope
     open-pull-requests-limit: 5
     labels:
       - dependencies


### PR DESCRIPTION
This commit removes the unwanted and unused property `commit-message` from the dependabot config.