### PR TITLE
ci: skip codecov for dependabot PRs

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -204,7 +204,7 @@ jobs:
 
   test-and-codecov:
     needs: check-changes
-    if: needs.check-changes.outputs.changes == 'true' || github.actor == 'dependabot[bot]'
+    if: needs.check-changes.outputs.changes == 'true' && github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/test-and-codecov.yaml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Dependabot PRs fail codecov upload with "Token required because branch is protected" error. This change modifies the test-and-codecov job condition to exclude dependabot PRs while maintaining normal codecov functionality for all other contributors.