### PR TITLE
chore: bump up Kepler to v0.11.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ ifeq ($(VERSION),)
 $(error VERSION cannot be empty)
 endif
 
-KEPLER_VERSION ?=v0.11.2
+KEPLER_VERSION ?=v0.11.3
 KUBE_RBAC_PROXY_VERSION ?=v0.19.0
 
 # IMG_BASE and KEPLER_IMG_BASE are set to distinguish between Operator-specific images and Kepler-Specific images.

--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.22.3
-    createdAt: "2025-11-13T06:04:17Z"
+    createdAt: "2025-11-25T06:41:25Z"
     description: Deploys and Manages Kepler on Kubernetes
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/internal-objects: |-
@@ -230,7 +230,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_KEPLER
-                  value: quay.io/sustainable_computing_io/kepler:v0.11.2
+                  value: quay.io/sustainable_computing_io/kepler:v0.11.3
                 - name: RELATED_IMAGE_KUBE_RBAC_PROXY
                   value: quay.io/brancz/kube-rbac-proxy:v0.19.0
                 image: quay.io/sustainable_computing_io/kepler-operator:0.22.3
@@ -340,7 +340,7 @@ spec:
     name: Kepler Operator Contributors
     url: https://sustainable-computing.io/
   relatedImages:
-  - image: quay.io/sustainable_computing_io/kepler:v0.11.2
+  - image: quay.io/sustainable_computing_io/kepler:v0.11.3
     name: kepler
   - image: quay.io/brancz/kube-rbac-proxy:v0.19.0
     name: kube-rbac-proxy

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	keplerImage        = `quay.io/sustainable_computing_io/kepler:v0.11.2`
+	keplerImage        = `quay.io/sustainable_computing_io/kepler:v0.11.3`
 	kubeRbacProxyImage = `quay.io/brancz/kube-rbac-proxy:v0.19.0`
 )
 


### PR DESCRIPTION
This commit bumps up Kepler to v0.11.3

NOTE: There is no new config changes introduced between Kepler v0.11.2 and v0.11.3.