### PR TITLE
fix(security): replace privileged with CAP_SYS_PTRACE

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -31,13 +31,9 @@ func NewNamespace(ns string) *corev1.Namespace {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: ns,
 			Labels: CommonLabels.Merge(k8s.StringMap{
-				// NOTE: Fixes the following error On Openshift 4.14
-				//   Warning  FailedCreate  daemonset-controller
-				//   Error creating: pods "kepler-exporter-ds-d6f28" is forbidden:
-				//   violates PodSecurity "restricted:latest":
-				//   privileged (container "kepler-exporter" must not set securityContext.privileged=true),
-				//   allowPrivilegeEscalation != false (container "kepler-exporter" must set
-				//   securityContext.allowPrivilegeEscalation=false),
+				// NOTE: Kepler requires hostPID and hostPath volumes for /proc and /sys access
+				// Only the "privileged" PSA level allows these host-level features
+				// However, the Kepler container itself does NOT run as privileged (privileged: false)
 				"pod-security.kubernetes.io/enforce": "privileged",
 			}),
 			//TODO: ensure in-cluster monitoring ignores this ns

--- a/pkg/components/power-monitor/deployment_test.go
+++ b/pkg/components/power-monitor/deployment_test.go
@@ -375,7 +375,7 @@ func TestSCCAllows(t *testing.T) {
 	}{
 		{
 			sccAllows: k8s.SCCAllows{
-				AllowPrivilegedContainer: true,
+				AllowPrivilegedContainer: false,
 				AllowHostDirVolumePlugin: true,
 				AllowHostIPC:             false,
 				AllowHostNetwork:         false,


### PR DESCRIPTION
Apply principle of least privilege by dropping all capabilities except CAP_SYS_PTRACE which Kepler needs to read /proc/<pid> Also enforce readonly root filesystem and prevent privilege escalation

Security improvements:
- Set privileged: false (no full root capabilities)
- Drop ALL capabilities, add only SYS_PTRACE
- Set allowPrivilegeEscalation: false
- Set readOnlyRootFilesystem: true
- Updated OpenShift SCC with same constraints