### PR TITLE
docs: replace crdoc with crd-ref-docs for API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ kepler-operator/
 - **Style**: Follow [Effective Go](https://go.dev/doc/effective_go) and idiomatic patterns
 - **Testing**: Use `testify` framework (assert/require)
 - **Functions**: Keep under 50-60 lines, single responsibility
-- **Documentation**: GoDoc comments for all exported items
+- **Documentation**: GoDoc comments for all exported items, especially CRD types (see below)
 
 ### Pre-commit Checks
 
@@ -233,7 +233,8 @@ Maintaining accurate and consistent documentation across the repository is criti
    - [ ] Update README.md for user-facing changes
    - [ ] Update user guides for feature changes
    - [ ] Update developer guides for architecture changes
-   - [ ] Regenerate API docs after CRD changes: `make docs`
+   - [ ] Add godoc comments to new/modified CRD types, fields, and constants
+   - [ ] Regenerate API docs after CRD changes: `make manifests generate bundle docs helm-sync-crds`
    - [ ] Verify all cross-document links still work
    - [ ] Ensure examples are tested and functional
 
@@ -253,6 +254,14 @@ Some documentation is auto-generated and should **never** be manually edited:
 - Helm chart dependencies - Synced via `make helm-sync-crds`
 
 Always regenerate these files when their sources change.
+
+#### CRD Type Documentation (GoDoc Comments)
+
+The API reference (`docs/user/reference/api.md`) is **generated from godoc comments** in `api/v1alpha1/*_types.go`. When modifying CRD types:
+
+1. Add godoc comments to all exported types, constants, and struct fields
+2. Follow [Go documentation conventions](https://go.dev/doc/effective_go#commentary): comments start with the name being documented, use present tense
+3. Regenerate docs: `make manifests generate bundle docs helm-sync-crds`
 
 #### Bundle Generation Guidelines
 

--- a/Makefile
+++ b/Makefile
@@ -143,8 +143,12 @@ coverage: test ## Run tests and generate coverage report.
 	go tool cover -html=cover.out -o cover.html
 
 .PHONY: docs
-docs: crdoc manifests ## Generate docs.
-	$(CRDOC) --resources config/crd/bases --output docs/user/reference/api.md
+docs: crd-ref-docs manifests ## Generate docs.
+	$(CRD_REF_DOCS) \
+		--source-path=./api/v1alpha1 \
+		--config=./hack/crd-ref-docs-config.yaml \
+		--renderer=markdown \
+		--output-path=docs/user/reference/api.md
 
 ##@ Development env
 CLUSTER_PROVIDER ?= kind
@@ -348,12 +352,12 @@ LOCALBIN ?= $(shell pwd)/tmp/bin
 ## Tool Binaries
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
-CRDOC ?= $(LOCALBIN)/crdoc
+CRD_REF_DOCS ?= $(LOCALBIN)/crd-ref-docs
 HELM ?= $(LOCALBIN)/helm
 
 # NOTE: please keep this list sorted so that it can be easily searched
 TOOLS = controller-gen \
-		crdoc \
+		crd-ref-docs \
 		govulncheck \
 		helm \
 		jq \

--- a/api/v1alpha1/power_monitor_internal_types.go
+++ b/api/v1alpha1/power_monitor_internal_types.go
@@ -7,30 +7,41 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// PowerMonitorInternalDashboardSpec defines settings for the Kepler Grafana dashboard
 type PowerMonitorInternalDashboardSpec struct {
+	// Enabled controls whether to deploy the Grafana dashboard
 	// +kubebuilder:default=false
 	Enabled bool `json:"enabled,omitempty"`
 }
 
+// PowerMonitorInternalOpenShiftSpec defines OpenShift-specific settings
 type PowerMonitorInternalOpenShiftSpec struct {
+	// Enabled controls whether OpenShift-specific features are enabled
 	// +kubebuilder:default=true
-	Enabled   bool                              `json:"enabled"`
+	Enabled bool `json:"enabled"`
+	// Dashboard configures the Grafana dashboard deployment
 	Dashboard PowerMonitorInternalDashboardSpec `json:"dashboard,omitempty"`
 }
 
+// PowerMonitorInternalKeplerDeploymentSpec extends PowerMonitorKeplerDeploymentSpec with internal deployment settings
 type PowerMonitorInternalKeplerDeploymentSpec struct {
 	PowerMonitorKeplerDeploymentSpec `json:",inline"`
+	// Image specifies the Kepler container image
 	// +kubebuilder:validation:MinLength=3
 	Image string `json:"image"`
 
+	// KubeRbacProxyImage specifies the kube-rbac-proxy sidecar image
 	// +kubebuilder:validation:MinLength=3
 	KubeRbacProxyImage string `json:"kubeRbacProxyImage,omitempty"`
 
+	// Namespace specifies the namespace where Kepler will be deployed
 	// +kubebuilder:validation:MinLength=1
 	Namespace string `json:"namespace"`
 }
 
+// PowerMonitorInternalKeplerConfigSpec defines configuration options for internal Kepler deployment
 type PowerMonitorInternalKeplerConfigSpec struct {
+	// LogLevel sets the logging verbosity (e.g., debug, info, warn, error)
 	// +kubebuilder:default="info"
 	LogLevel string `json:"logLevel,omitempty"`
 
@@ -73,16 +84,21 @@ type PowerMonitorInternalKeplerConfigSpec struct {
 	MaxTerminated *int32 `json:"maxTerminated,omitempty"`
 }
 
+// PowerMonitorInternalKeplerSpec defines the internal Kepler component specification
 type PowerMonitorInternalKeplerSpec struct {
+	// Deployment contains the deployment settings for the internal Kepler DaemonSet
 	// +kubebuilder:validation:Required
 	Deployment PowerMonitorInternalKeplerDeploymentSpec `json:"deployment"`
-	Config     PowerMonitorInternalKeplerConfigSpec     `json:"config,omitempty"`
+	// Config contains the configuration options for internal Kepler
+	Config PowerMonitorInternalKeplerConfigSpec `json:"config,omitempty"`
 }
 
-// PowerMonitorInternalSpec defines the desired state of PowerMonitorInternalSpec
+// PowerMonitorInternalSpec defines the desired state of PowerMonitorInternal
 type PowerMonitorInternalSpec struct {
+	// Kepler contains the Kepler component specification
 	// +kubebuilder:validation:Required
-	Kepler    PowerMonitorInternalKeplerSpec    `json:"kepler"`
+	Kepler PowerMonitorInternalKeplerSpec `json:"kepler"`
+	// OpenShift contains OpenShift-specific settings
 	OpenShift PowerMonitorInternalOpenShiftSpec `json:"openshift,omitempty"`
 }
 
@@ -109,8 +125,9 @@ type PowerMonitorInternal struct {
 	Status PowerMonitorInternalStatus `json:"status,omitempty"`
 }
 
+// PowerMonitorInternalKeplerStatus defines the observed state of the internal Kepler DaemonSet
 type PowerMonitorInternalKeplerStatus struct {
-	// The number of nodes that are running at least 1 power-monitor-internal pod and are
+	// CurrentNumberScheduled is the number of nodes that are running at least 1 power-monitor-internal pod and are
 	// supposed to run the power-monitor-internal pod.
 	CurrentNumberScheduled int32 `json:"currentNumberScheduled"`
 
@@ -141,7 +158,9 @@ type PowerMonitorInternalKeplerStatus struct {
 	NumberUnavailable int32 `json:"numberUnavailable,omitempty"`
 }
 
+// PowerMonitorInternalStatus defines the observed state of PowerMonitorInternal
 type PowerMonitorInternalStatus struct {
+	// Kepler contains the status of the internal Kepler DaemonSet
 	Kepler PowerMonitorInternalKeplerStatus `json:"kepler,omitempty"`
 	// conditions represent the latest available observations of power-monitor-internal
 	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors="urn:alm:descriptor:com.tectonic.ui:conditions"

--- a/api/v1alpha1/power_monitor_types.go
+++ b/api/v1alpha1/power_monitor_types.go
@@ -15,16 +15,22 @@ const (
 	InvalidPowerMonitorResource ConditionReason = "InvalidPowerMonitorResource"
 )
 
+// SecurityMode defines the security mode for Kepler metrics access
 type SecurityMode string
 
 const (
+	// SecurityModeNone disables RBAC-based access control for Kepler metrics
 	SecurityModeNone SecurityMode = "none"
+	// SecurityModeRBAC enables RBAC-based access control for Kepler metrics
 	SecurityModeRBAC SecurityMode = "rbac"
 )
 
+// PowerMonitorKeplerDeploymentSecuritySpec defines security settings for the Kepler deployment
 type PowerMonitorKeplerDeploymentSecuritySpec struct {
+	// Mode specifies the security mode (none or rbac)
 	// +kubebuilder:validation:Enum=none;rbac
 	Mode SecurityMode `json:"mode,omitempty"`
+	// AllowedSANames lists service account names allowed to access Kepler metrics
 	// +optional
 	// +listType=atomic
 	AllowedSANames []string `json:"allowedSANames,omitempty"`
@@ -33,8 +39,9 @@ type PowerMonitorKeplerDeploymentSecuritySpec struct {
 // MetricsLevelDefault represents the default metric levels for PowerMonitor (node, pod, and vm)
 const MetricsLevelDefault = config.MetricsLevelNode | config.MetricsLevelPod | config.MetricsLevelVM
 
+// PowerMonitorKeplerDeploymentSpec defines deployment settings for the Kepler DaemonSet
 type PowerMonitorKeplerDeploymentSpec struct {
-	// Defines which Nodes the Pod is scheduled on
+	// NodeSelector defines which Nodes the Pod is scheduled on
 	// +optional
 	// +kubebuilder:default={"kubernetes.io/os":"linux"}
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
@@ -53,7 +60,9 @@ type PowerMonitorKeplerDeploymentSpec struct {
 	Secrets []SecretRef `json:"secrets,omitempty"`
 }
 
+// PowerMonitorKeplerConfigSpec defines configuration options for Kepler
 type PowerMonitorKeplerConfigSpec struct {
+	// LogLevel sets the logging verbosity (e.g., debug, info, warn, error)
 	// +kubebuilder:default="info"
 	// +optional
 	LogLevel string `json:"logLevel,omitempty"`
@@ -138,9 +147,12 @@ type SecretRef struct {
 	ReadOnly *bool `json:"readOnly,omitempty"`
 }
 
+// PowerMonitorKeplerSpec defines the Kepler component specification
 type PowerMonitorKeplerSpec struct {
+	// Deployment contains the deployment settings for the Kepler DaemonSet
 	Deployment PowerMonitorKeplerDeploymentSpec `json:"deployment,omitempty"`
-	Config     PowerMonitorKeplerConfigSpec     `json:"config,omitempty"`
+	// Config contains the configuration options for Kepler
+	Config PowerMonitorKeplerConfigSpec `json:"config,omitempty"`
 }
 
 // PowerMonitorSpec defines the desired state of Power Monitor
@@ -170,8 +182,9 @@ type PowerMonitor struct {
 	Status PowerMonitorStatus `json:"status,omitempty"`
 }
 
+// PowerMonitorKeplerStatus defines the observed state of the Kepler DaemonSet
 type PowerMonitorKeplerStatus struct {
-	// The number of nodes that are running at least 1 power-monitor pod and are
+	// CurrentNumberScheduled is the number of nodes that are running at least 1 power-monitor pod and are
 	// supposed to run the power-monitor pod.
 	CurrentNumberScheduled int32 `json:"currentNumberScheduled"`
 
@@ -202,13 +215,17 @@ type PowerMonitorKeplerStatus struct {
 	NumberUnavailable int32 `json:"numberUnavailable,omitempty"`
 }
 
+// ConditionType represents the type of condition for a PowerMonitor resource
 type ConditionType string
 
 const (
-	Available  ConditionType = "Available"
+	// Available indicates whether the PowerMonitor is available and serving metrics
+	Available ConditionType = "Available"
+	// Reconciled indicates whether the PowerMonitor has been successfully reconciled
 	Reconciled ConditionType = "Reconciled"
 )
 
+// ConditionReason represents the reason for a condition's last transition
 type ConditionReason string
 
 const (
@@ -219,15 +236,23 @@ const (
 	ReconcileError ConditionReason = "ReconcileError"
 
 	// DaemonSetNotFound indicates the DaemonSet created for a kepler was not found
-	DaemonSetNotFound           ConditionReason = "DaemonSetNotFound"
-	DaemonSetError              ConditionReason = "DaemonSetError"
-	DaemonSetInProgess          ConditionReason = "DaemonSetInProgress"
-	DaemonSetUnavailable        ConditionReason = "DaemonSetUnavailable"
+	DaemonSetNotFound ConditionReason = "DaemonSetNotFound"
+	// DaemonSetError indicates an error occurred with the DaemonSet
+	DaemonSetError ConditionReason = "DaemonSetError"
+	// DaemonSetInProgess indicates the DaemonSet is being updated
+	DaemonSetInProgess ConditionReason = "DaemonSetInProgress"
+	// DaemonSetUnavailable indicates no DaemonSet pods are available
+	DaemonSetUnavailable ConditionReason = "DaemonSetUnavailable"
+	// DaemonSetPartiallyAvailable indicates some but not all DaemonSet pods are available
 	DaemonSetPartiallyAvailable ConditionReason = "DaemonSetPartiallyAvailable"
-	DaemonSetPodsNotRunning     ConditionReason = "DaemonSetPodsNotRunning"
-	DaemonSetRolloutInProgress  ConditionReason = "DaemonSetRolloutInProgress"
-	DaemonSetReady              ConditionReason = "DaemonSetReady"
-	DaemonSetOutOfSync          ConditionReason = "DaemonSetOutOfSync"
+	// DaemonSetPodsNotRunning indicates DaemonSet pods exist but are not running
+	DaemonSetPodsNotRunning ConditionReason = "DaemonSetPodsNotRunning"
+	// DaemonSetRolloutInProgress indicates a DaemonSet rollout is in progress
+	DaemonSetRolloutInProgress ConditionReason = "DaemonSetRolloutInProgress"
+	// DaemonSetReady indicates the DaemonSet is fully available and ready
+	DaemonSetReady ConditionReason = "DaemonSetReady"
+	// DaemonSetOutOfSync indicates the DaemonSet spec doesn't match the desired state
+	DaemonSetOutOfSync ConditionReason = "DaemonSetOutOfSync"
 
 	// SecretNotFound indicates one or more referenced secrets are missing
 	SecretNotFound ConditionReason = "SecretNotFound"
@@ -241,9 +266,13 @@ const (
 type ConditionStatus string
 
 const (
-	ConditionTrue     ConditionStatus = "True"
-	ConditionFalse    ConditionStatus = "False"
-	ConditionUnknown  ConditionStatus = "Unknown"
+	// ConditionTrue indicates the condition is met
+	ConditionTrue ConditionStatus = "True"
+	// ConditionFalse indicates the condition is not met
+	ConditionFalse ConditionStatus = "False"
+	// ConditionUnknown indicates the condition status cannot be determined
+	ConditionUnknown ConditionStatus = "Unknown"
+	// ConditionDegraded indicates the resource is operational but in a degraded state
 	ConditionDegraded ConditionStatus = "Degraded"
 )
 

--- a/bundle/manifests/kepler.system.sustainable.computing.io_powermonitorinternals.yaml
+++ b/bundle/manifests/kepler.system.sustainable.computing.io_powermonitorinternals.yaml
@@ -68,11 +68,14 @@ spec:
           metadata:
             type: object
           spec:
-            description: PowerMonitorInternalSpec defines the desired state of PowerMonitorInternalSpec
+            description: PowerMonitorInternalSpec defines the desired state of PowerMonitorInternal
             properties:
               kepler:
+                description: Kepler contains the Kepler component specification
                 properties:
                   config:
+                    description: Config contains the configuration options for internal
+                      Kepler
                     properties:
                       additionalConfigMaps:
                         description: |-
@@ -92,6 +95,8 @@ spec:
                         x-kubernetes-list-type: atomic
                       logLevel:
                         default: info
+                        description: LogLevel sets the logging verbosity (e.g., debug,
+                          info, warn, error)
                         type: string
                       maxTerminated:
                         default: 0
@@ -136,14 +141,21 @@ spec:
                         type: string
                     type: object
                   deployment:
+                    description: Deployment contains the deployment settings for the
+                      internal Kepler DaemonSet
                     properties:
                       image:
+                        description: Image specifies the Kepler container image
                         minLength: 3
                         type: string
                       kubeRbacProxyImage:
+                        description: KubeRbacProxyImage specifies the kube-rbac-proxy
+                          sidecar image
                         minLength: 3
                         type: string
                       namespace:
+                        description: Namespace specifies the namespace where Kepler
+                          will be deployed
                         minLength: 1
                         type: string
                       nodeSelector:
@@ -151,7 +163,8 @@ spec:
                           type: string
                         default:
                           kubernetes.io/os: linux
-                        description: Defines which Nodes the Pod is scheduled on
+                        description: NodeSelector defines which Nodes the Pod is scheduled
+                          on
                         type: object
                       secrets:
                         description: Secrets to be mounted in the power monitor containers
@@ -199,11 +212,15 @@ spec:
                           SANames
                         properties:
                           allowedSANames:
+                            description: AllowedSANames lists service account names
+                              allowed to access Kepler metrics
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           mode:
+                            description: Mode specifies the security mode (none or
+                              rbac)
                             enum:
                             - none
                             - rbac
@@ -261,15 +278,21 @@ spec:
                 - deployment
                 type: object
               openshift:
+                description: OpenShift contains OpenShift-specific settings
                 properties:
                   dashboard:
+                    description: Dashboard configures the Grafana dashboard deployment
                     properties:
                       enabled:
                         default: false
+                        description: Enabled controls whether to deploy the Grafana
+                          dashboard
                         type: boolean
                     type: object
                   enabled:
                     default: true
+                    description: Enabled controls whether OpenShift-specific features
+                      are enabled
                     type: boolean
                 required:
                 - enabled
@@ -278,6 +301,8 @@ spec:
             - kepler
             type: object
           status:
+            description: PowerMonitorInternalStatus defines the observed state of
+              PowerMonitorInternal
             properties:
               conditions:
                 description: conditions represent the latest available observations
@@ -325,10 +350,11 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               kepler:
+                description: Kepler contains the status of the internal Kepler DaemonSet
                 properties:
                   currentNumberScheduled:
                     description: |-
-                      The number of nodes that are running at least 1 power-monitor-internal pod and are
+                      CurrentNumberScheduled is the number of nodes that are running at least 1 power-monitor-internal pod and are
                       supposed to run the power-monitor-internal pod.
                     format: int32
                     type: integer

--- a/bundle/manifests/kepler.system.sustainable.computing.io_powermonitors.yaml
+++ b/bundle/manifests/kepler.system.sustainable.computing.io_powermonitors.yaml
@@ -77,8 +77,10 @@ spec:
             description: PowerMonitorSpec defines the desired state of Power Monitor
             properties:
               kepler:
+                description: PowerMonitorKeplerSpec defines the Kepler component specification
                 properties:
                   config:
+                    description: Config contains the configuration options for Kepler
                     properties:
                       additionalConfigMaps:
                         description: |-
@@ -98,6 +100,8 @@ spec:
                         x-kubernetes-list-type: atomic
                       logLevel:
                         default: info
+                        description: LogLevel sets the logging verbosity (e.g., debug,
+                          info, warn, error)
                         type: string
                       maxTerminated:
                         default: 0
@@ -142,13 +146,16 @@ spec:
                         type: string
                     type: object
                   deployment:
+                    description: Deployment contains the deployment settings for the
+                      Kepler DaemonSet
                     properties:
                       nodeSelector:
                         additionalProperties:
                           type: string
                         default:
                           kubernetes.io/os: linux
-                        description: Defines which Nodes the Pod is scheduled on
+                        description: NodeSelector defines which Nodes the Pod is scheduled
+                          on
                         type: object
                       secrets:
                         description: Secrets to be mounted in the power monitor containers
@@ -196,11 +203,15 @@ spec:
                           SANames
                         properties:
                           allowedSANames:
+                            description: AllowedSANames lists service account names
+                              allowed to access Kepler metrics
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           mode:
+                            description: Mode specifies the security mode (none or
+                              rbac)
                             enum:
                             - none
                             - rbac
@@ -304,10 +315,12 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               kepler:
+                description: PowerMonitorKeplerStatus defines the observed state of
+                  the Kepler DaemonSet
                 properties:
                   currentNumberScheduled:
                     description: |-
-                      The number of nodes that are running at least 1 power-monitor pod and are
+                      CurrentNumberScheduled is the number of nodes that are running at least 1 power-monitor pod and are
                       supposed to run the power-monitor pod.
                     format: int32
                     type: integer

--- a/config/crd/bases/kepler.system.sustainable.computing.io_powermonitorinternals.yaml
+++ b/config/crd/bases/kepler.system.sustainable.computing.io_powermonitorinternals.yaml
@@ -68,11 +68,14 @@ spec:
           metadata:
             type: object
           spec:
-            description: PowerMonitorInternalSpec defines the desired state of PowerMonitorInternalSpec
+            description: PowerMonitorInternalSpec defines the desired state of PowerMonitorInternal
             properties:
               kepler:
+                description: Kepler contains the Kepler component specification
                 properties:
                   config:
+                    description: Config contains the configuration options for internal
+                      Kepler
                     properties:
                       additionalConfigMaps:
                         description: |-
@@ -92,6 +95,8 @@ spec:
                         x-kubernetes-list-type: atomic
                       logLevel:
                         default: info
+                        description: LogLevel sets the logging verbosity (e.g., debug,
+                          info, warn, error)
                         type: string
                       maxTerminated:
                         default: 0
@@ -136,14 +141,21 @@ spec:
                         type: string
                     type: object
                   deployment:
+                    description: Deployment contains the deployment settings for the
+                      internal Kepler DaemonSet
                     properties:
                       image:
+                        description: Image specifies the Kepler container image
                         minLength: 3
                         type: string
                       kubeRbacProxyImage:
+                        description: KubeRbacProxyImage specifies the kube-rbac-proxy
+                          sidecar image
                         minLength: 3
                         type: string
                       namespace:
+                        description: Namespace specifies the namespace where Kepler
+                          will be deployed
                         minLength: 1
                         type: string
                       nodeSelector:
@@ -151,7 +163,8 @@ spec:
                           type: string
                         default:
                           kubernetes.io/os: linux
-                        description: Defines which Nodes the Pod is scheduled on
+                        description: NodeSelector defines which Nodes the Pod is scheduled
+                          on
                         type: object
                       secrets:
                         description: Secrets to be mounted in the power monitor containers
@@ -199,11 +212,15 @@ spec:
                           SANames
                         properties:
                           allowedSANames:
+                            description: AllowedSANames lists service account names
+                              allowed to access Kepler metrics
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           mode:
+                            description: Mode specifies the security mode (none or
+                              rbac)
                             enum:
                             - none
                             - rbac
@@ -261,15 +278,21 @@ spec:
                 - deployment
                 type: object
               openshift:
+                description: OpenShift contains OpenShift-specific settings
                 properties:
                   dashboard:
+                    description: Dashboard configures the Grafana dashboard deployment
                     properties:
                       enabled:
                         default: false
+                        description: Enabled controls whether to deploy the Grafana
+                          dashboard
                         type: boolean
                     type: object
                   enabled:
                     default: true
+                    description: Enabled controls whether OpenShift-specific features
+                      are enabled
                     type: boolean
                 required:
                 - enabled
@@ -278,6 +301,8 @@ spec:
             - kepler
             type: object
           status:
+            description: PowerMonitorInternalStatus defines the observed state of
+              PowerMonitorInternal
             properties:
               conditions:
                 description: conditions represent the latest available observations
@@ -325,10 +350,11 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               kepler:
+                description: Kepler contains the status of the internal Kepler DaemonSet
                 properties:
                   currentNumberScheduled:
                     description: |-
-                      The number of nodes that are running at least 1 power-monitor-internal pod and are
+                      CurrentNumberScheduled is the number of nodes that are running at least 1 power-monitor-internal pod and are
                       supposed to run the power-monitor-internal pod.
                     format: int32
                     type: integer

--- a/config/crd/bases/kepler.system.sustainable.computing.io_powermonitors.yaml
+++ b/config/crd/bases/kepler.system.sustainable.computing.io_powermonitors.yaml
@@ -67,8 +67,10 @@ spec:
             description: PowerMonitorSpec defines the desired state of Power Monitor
             properties:
               kepler:
+                description: PowerMonitorKeplerSpec defines the Kepler component specification
                 properties:
                   config:
+                    description: Config contains the configuration options for Kepler
                     properties:
                       additionalConfigMaps:
                         description: |-
@@ -88,6 +90,8 @@ spec:
                         x-kubernetes-list-type: atomic
                       logLevel:
                         default: info
+                        description: LogLevel sets the logging verbosity (e.g., debug,
+                          info, warn, error)
                         type: string
                       maxTerminated:
                         default: 0
@@ -132,13 +136,16 @@ spec:
                         type: string
                     type: object
                   deployment:
+                    description: Deployment contains the deployment settings for the
+                      Kepler DaemonSet
                     properties:
                       nodeSelector:
                         additionalProperties:
                           type: string
                         default:
                           kubernetes.io/os: linux
-                        description: Defines which Nodes the Pod is scheduled on
+                        description: NodeSelector defines which Nodes the Pod is scheduled
+                          on
                         type: object
                       secrets:
                         description: Secrets to be mounted in the power monitor containers
@@ -186,11 +193,15 @@ spec:
                           SANames
                         properties:
                           allowedSANames:
+                            description: AllowedSANames lists service account names
+                              allowed to access Kepler metrics
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           mode:
+                            description: Mode specifies the security mode (none or
+                              rbac)
                             enum:
                             - none
                             - rbac
@@ -294,10 +305,12 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               kepler:
+                description: PowerMonitorKeplerStatus defines the observed state of
+                  the Kepler DaemonSet
                 properties:
                   currentNumberScheduled:
                     description: |-
-                      The number of nodes that are running at least 1 power-monitor pod and are
+                      CurrentNumberScheduled is the number of nodes that are running at least 1 power-monitor pod and are
                       supposed to run the power-monitor pod.
                     format: int32
                     type: integer

--- a/docs/user/reference/api.md
+++ b/docs/user/reference/api.md
@@ -1,1016 +1,489 @@
 # API Reference
 
-Packages:
-
+## Packages
 - [kepler.system.sustainable.computing.io/v1alpha1](#keplersystemsustainablecomputingiov1alpha1)
 
-# kepler.system.sustainable.computing.io/v1alpha1
 
-Resource Types:
+## kepler.system.sustainable.computing.io/v1alpha1
 
-- [PowerMonitorInternal](#powermonitorinternal)
+Package v1alpha1 contains API Schema definitions for the kepler.system v1alpha1 API group
 
+### Resource Types
 - [PowerMonitor](#powermonitor)
+- [PowerMonitorInternal](#powermonitorinternal)
+- [PowerMonitorInternalList](#powermonitorinternallist)
+- [PowerMonitorList](#powermonitorlist)
 
 
 
-
-## PowerMonitorInternal
-<sup><sup>[↩ Parent](#keplersystemsustainablecomputingiov1alpha1 )</sup></sup>
-
-
-
-
-
-
-PowerMonitorInternal is the Schema for the internal kepler 2 API
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-      <td><b>apiVersion</b></td>
-      <td>string</td>
-      <td>kepler.system.sustainable.computing.io/v1alpha1</td>
-      <td>true</td>
-      </tr>
-      <tr>
-      <td><b>kind</b></td>
-      <td>string</td>
-      <td>PowerMonitorInternal</td>
-      <td>true</td>
-      </tr>
-      <tr>
-      <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">metadata</a></b></td>
-      <td>object</td>
-      <td>Refer to the Kubernetes API documentation for the fields of the `metadata` field.</td>
-      <td>true</td>
-      </tr><tr>
-        <td><b><a href="#powermonitorinternalspec">spec</a></b></td>
-        <td>object</td>
-        <td>
-          PowerMonitorInternalSpec defines the desired state of PowerMonitorInternalSpec<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b><a href="#powermonitorinternalstatus">status</a></b></td>
-        <td>object</td>
-        <td>
-          <br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-
-### PowerMonitorInternal.spec
-<sup><sup>[↩ Parent](#powermonitorinternal)</sup></sup>
-
-
-
-PowerMonitorInternalSpec defines the desired state of PowerMonitorInternalSpec
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b><a href="#powermonitorinternalspeckepler">kepler</a></b></td>
-        <td>object</td>
-        <td>
-          <br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b><a href="#powermonitorinternalspecopenshift">openshift</a></b></td>
-        <td>object</td>
-        <td>
-          <br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-
-### PowerMonitorInternal.spec.kepler
-<sup><sup>[↩ Parent](#powermonitorinternalspec)</sup></sup>
+#### Condition
 
 
 
 
 
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b><a href="#powermonitorinternalspeckeplerdeployment">deployment</a></b></td>
-        <td>object</td>
-        <td>
-          <br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b><a href="#powermonitorinternalspeckeplerconfig">config</a></b></td>
-        <td>object</td>
-        <td>
-          <br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
 
 
-### PowerMonitorInternal.spec.kepler.deployment
-<sup><sup>[↩ Parent](#powermonitorinternalspeckepler)</sup></sup>
+_Appears in:_
+- [PowerMonitorInternalStatus](#powermonitorinternalstatus)
+- [PowerMonitorStatus](#powermonitorstatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `type` _[ConditionType](#conditiontype)_ | Type of Kepler Condition - Reconciled, Available ... |  |  |
+| `status` _[ConditionStatus](#conditionstatus)_ | status of the condition, one of True, False, Unknown. |  |  |
+| `observedGeneration` _integer_ | observedGeneration represents the .metadata.generation that the condition was set based upon.<br />For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date<br />with respect to the current state of the instance. |  | Minimum: 0 <br /> |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#time-v1-meta)_ | lastTransitionTime is the last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable. |  | Format: date-time <br />Required: \{\} <br />Type: string <br /> |
+| `reason` _[ConditionReason](#conditionreason)_ | reason contains a programmatic identifier indicating the reason for the condition's last transition. |  |  |
+| `message` _string_ | message is a human readable message indicating details about the transition.<br />This may be an empty string. |  | MaxLength: 32768 <br />Required: \{\} <br /> |
+
+
+#### ConditionReason
+
+_Underlying type:_ _string_
+
+ConditionReason represents the reason for a condition's last transition
 
 
 
+_Appears in:_
+- [Condition](#condition)
+
+| Field | Description |
+| --- | --- |
+| `InvalidPowerMonitorResource` | InvalidPowerMonitorResource indicates the CR name was invalid<br /> |
+| `ReconcileSuccess` | ReconcileComplete indicates the CR was successfully reconciled<br /> |
+| `ReconcileError` | ReconcileError indicates an error was encountered while reconciling the CR<br /> |
+| `DaemonSetNotFound` | DaemonSetNotFound indicates the DaemonSet created for a kepler was not found<br /> |
+| `DaemonSetError` | DaemonSetError indicates an error occurred with the DaemonSet<br /> |
+| `DaemonSetInProgress` | DaemonSetInProgess indicates the DaemonSet is being updated<br /> |
+| `DaemonSetUnavailable` | DaemonSetUnavailable indicates no DaemonSet pods are available<br /> |
+| `DaemonSetPartiallyAvailable` | DaemonSetPartiallyAvailable indicates some but not all DaemonSet pods are available<br /> |
+| `DaemonSetPodsNotRunning` | DaemonSetPodsNotRunning indicates DaemonSet pods exist but are not running<br /> |
+| `DaemonSetRolloutInProgress` | DaemonSetRolloutInProgress indicates a DaemonSet rollout is in progress<br /> |
+| `DaemonSetReady` | DaemonSetReady indicates the DaemonSet is fully available and ready<br /> |
+| `DaemonSetOutOfSync` | DaemonSetOutOfSync indicates the DaemonSet spec doesn't match the desired state<br /> |
+| `SecretNotFound` | SecretNotFound indicates one or more referenced secrets are missing<br /> |
 
 
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>image</b></td>
-        <td>string</td>
-        <td>
-          <br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>namespace</b></td>
-        <td>string</td>
-        <td>
-          <br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>kubeRbacProxyImage</b></td>
-        <td>string</td>
-        <td>
-          <br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>nodeSelector</b></td>
-        <td>map[string]string</td>
-        <td>
-          Defines which Nodes the Pod is scheduled on<br/>
-          <br/>
-            <i>Default</i>: map[kubernetes.io/os:linux]<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b><a href="#powermonitorinternalspeckeplerdeploymentsecretsindex">secrets</a></b></td>
-        <td>[]object</td>
-        <td>
-          Secrets to be mounted in the power monitor containers<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b><a href="#powermonitorinternalspeckeplerdeploymentsecurity">security</a></b></td>
-        <td>object</td>
-        <td>
-          If set, defines the security mode and allowed SANames<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b><a href="#powermonitorinternalspeckeplerdeploymenttolerationsindex">tolerations</a></b></td>
-        <td>[]object</td>
-        <td>
-          If specified, define Pod's tolerations<br/>
-          <br/>
-            <i>Default</i>: [map[effect: key: operator:Exists value:]]<br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
+#### ConditionStatus
 
+_Underlying type:_ _string_
 
-### PowerMonitorInternal.spec.kepler.deployment.secrets[index]
-<sup><sup>[↩ Parent](#powermonitorinternalspeckeplerdeployment)</sup></sup>
+These are valid condition statuses.
+"ConditionTrue" means a resource is in the condition.
+"ConditionFalse" means a resource is not in the condition.
+"ConditionUnknown" means kubernetes can't decide if a resource is in the condition or not.
+In the future, we could add other intermediate conditions, e.g. ConditionDegraded.
 
 
 
-SecretRef defines a reference to a Secret to be mounted
+_Appears in:_
+- [Condition](#condition)
 
-Mount Path Cautions:
-Exercise caution when setting mount paths for secrets. Avoid mounting secrets to critical system paths
-that may interfere with Kepler's operation or container security:
-- /etc/kepler - Reserved for Kepler configuration files
-- /sys, /proc, /dev - System directories that should remain read-only
-- /usr, /bin, /sbin, /lib - System binaries and libraries
-- / - Root filesystem
-
-Best practices:
-- Use subdirectories like /etc/kepler/secrets/ or /opt/secrets/
-- Ensure mount paths don't conflict with existing volume mounts
-- Test mount paths in development environments before production deployment
-- Monitor Kepler pod logs for mount-related errors
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>mountPath</b></td>
-        <td>string</td>
-        <td>
-          MountPath where the secret should be mounted in the container<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>name</b></td>
-        <td>string</td>
-        <td>
-          Name of the secret in the same namespace as the Kepler deployment<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>readOnly</b></td>
-        <td>boolean</td>
-        <td>
-          ReadOnly specifies whether the secret should be mounted read-only<br/>
-          <br/>
-            <i>Default</i>: true<br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
+| Field | Description |
+| --- | --- |
+| `True` | ConditionTrue indicates the condition is met<br /> |
+| `False` | ConditionFalse indicates the condition is not met<br /> |
+| `Unknown` | ConditionUnknown indicates the condition status cannot be determined<br /> |
+| `Degraded` | ConditionDegraded indicates the resource is operational but in a degraded state<br /> |
 
 
-### PowerMonitorInternal.spec.kepler.deployment.security
-<sup><sup>[↩ Parent](#powermonitorinternalspeckeplerdeployment)</sup></sup>
+#### ConditionType
+
+_Underlying type:_ _string_
+
+ConditionType represents the type of condition for a PowerMonitor resource
 
 
 
-If set, defines the security mode and allowed SANames
+_Appears in:_
+- [Condition](#condition)
 
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>allowedSANames</b></td>
-        <td>[]string</td>
-        <td>
-          <br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>mode</b></td>
-        <td>enum</td>
-        <td>
-          <br/>
-          <br/>
-            <i>Enum</i>: none, rbac<br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
+| Field | Description |
+| --- | --- |
+| `Available` | Available indicates whether the PowerMonitor is available and serving metrics<br /> |
+| `Reconciled` | Reconciled indicates whether the PowerMonitor has been successfully reconciled<br /> |
 
 
-### PowerMonitorInternal.spec.kepler.deployment.tolerations[index]
-<sup><sup>[↩ Parent](#powermonitorinternalspeckeplerdeployment)</sup></sup>
-
-
-
-The pod this Toleration is attached to tolerates any taint that matches
-the triple <key,value,effect> using the matching operator <operator>.
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>effect</b></td>
-        <td>string</td>
-        <td>
-          Effect indicates the taint effect to match. Empty means match all taint effects.
-When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>key</b></td>
-        <td>string</td>
-        <td>
-          Key is the taint key that the toleration applies to. Empty means match all taint keys.
-If the key is empty, operator must be Exists; this combination means to match all values and all keys.<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>operator</b></td>
-        <td>string</td>
-        <td>
-          Operator represents a key's relationship to the value.
-Valid operators are Exists and Equal. Defaults to Equal.
-Exists is equivalent to wildcard for value, so that a pod can
-tolerate all taints of a particular category.<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>tolerationSeconds</b></td>
-        <td>integer</td>
-        <td>
-          TolerationSeconds represents the period of time the toleration (which must be
-of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-it is not set, which means tolerate the taint forever (do not evict). Zero and
-negative values will be treated as 0 (evict immediately) by the system.<br/>
-          <br/>
-            <i>Format</i>: int64<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>value</b></td>
-        <td>string</td>
-        <td>
-          Value is the taint value the toleration matches to.
-If the operator is Exists, the value should be empty, otherwise just a regular string.<br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-
-### PowerMonitorInternal.spec.kepler.config
-<sup><sup>[↩ Parent](#powermonitorinternalspeckepler)</sup></sup>
-
-
-
-
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b><a href="#powermonitorinternalspeckeplerconfigadditionalconfigmapsindex">additionalConfigMaps</a></b></td>
-        <td>[]object</td>
-        <td>
-          AdditionalConfigMaps is a list of ConfigMap names that will be merged with the default ConfigMap
-These AdditionalConfigMaps must exist in the same namespace as PowerMonitor components<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>logLevel</b></td>
-        <td>string</td>
-        <td>
-          <br/>
-          <br/>
-            <i>Default</i>: info<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>maxTerminated</b></td>
-        <td>integer</td>
-        <td>
-          MaxTerminated controls terminated workload tracking behavior
-Negative values: track unlimited terminated workloads (no capacity limit)
-Zero: disable terminated workload tracking completely
-Positive values: track top N terminated workloads by energy consumption<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Default</i>: 0<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>metricLevels</b></td>
-        <td>[]enum</td>
-        <td>
-          MetricLevels specifies which metrics levels to export
-Valid values are combinations of: node, process, container, vm, pod<br/>
-          <br/>
-            <i>Default</i>: [node pod vm]<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>sampleRate</b></td>
-        <td>string</td>
-        <td>
-          SampleRate specifies the interval for monitoring resources (processes, containers, vms, etc.)
-Must be a positive duration (e.g., "5s", "1m", "30s"). Negative values are not allowed.<br/>
-          <br/>
-            <i>Default</i>: 5s<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>staleness</b></td>
-        <td>string</td>
-        <td>
-          Staleness specifies how long to wait before considering calculated power values as stale
-Must be a positive duration (e.g., "500ms", "5s", "1h"). Negative values are not allowed.<br/>
-          <br/>
-            <i>Default</i>: 500ms<br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-
-### PowerMonitorInternal.spec.kepler.config.additionalConfigMaps[index]
-<sup><sup>[↩ Parent](#powermonitorinternalspeckeplerconfig)</sup></sup>
+#### ConfigMapRef
 
 
 
 ConfigMapRef defines a reference to a ConfigMap
 
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>name</b></td>
-        <td>string</td>
-        <td>
-          Name of the ConfigMap<br/>
-        </td>
-        <td>true</td>
-      </tr></tbody>
-</table>
 
 
-### PowerMonitorInternal.spec.openshift
-<sup><sup>[↩ Parent](#powermonitorinternalspec)</sup></sup>
+_Appears in:_
+- [PowerMonitorInternalKeplerConfigSpec](#powermonitorinternalkeplerconfigspec)
+- [PowerMonitorKeplerConfigSpec](#powermonitorkeplerconfigspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the ConfigMap |  | MinLength: 1 <br /> |
 
 
-
-
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>enabled</b></td>
-        <td>boolean</td>
-        <td>
-          <br/>
-          <br/>
-            <i>Default</i>: true<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b><a href="#powermonitorinternalspecopenshiftdashboard">dashboard</a></b></td>
-        <td>object</td>
-        <td>
-          <br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-
-### PowerMonitorInternal.spec.openshift.dashboard
-<sup><sup>[↩ Parent](#powermonitorinternalspecopenshift)</sup></sup>
-
-
-
-
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>enabled</b></td>
-        <td>boolean</td>
-        <td>
-          <br/>
-          <br/>
-            <i>Default</i>: false<br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-
-### PowerMonitorInternal.status
-<sup><sup>[↩ Parent](#powermonitorinternal)</sup></sup>
-
-
-
-
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b><a href="#powermonitorinternalstatusconditionsindex">conditions</a></b></td>
-        <td>[]object</td>
-        <td>
-          conditions represent the latest available observations of power-monitor-internal<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b><a href="#powermonitorinternalstatuskepler">kepler</a></b></td>
-        <td>object</td>
-        <td>
-          <br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-
-### PowerMonitorInternal.status.conditions[index]
-<sup><sup>[↩ Parent](#powermonitorinternalstatus)</sup></sup>
-
-
-
-
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>lastTransitionTime</b></td>
-        <td>string</td>
-        <td>
-          lastTransitionTime is the last time the condition transitioned from one status to another.
-This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.<br/>
-          <br/>
-            <i>Format</i>: date-time<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>message</b></td>
-        <td>string</td>
-        <td>
-          message is a human readable message indicating details about the transition.
-This may be an empty string.<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>reason</b></td>
-        <td>string</td>
-        <td>
-          reason contains a programmatic identifier indicating the reason for the condition's last transition.<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>status</b></td>
-        <td>string</td>
-        <td>
-          status of the condition, one of True, False, Unknown.<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>type</b></td>
-        <td>string</td>
-        <td>
-          Type of Kepler Condition - Reconciled, Available ...<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>observedGeneration</b></td>
-        <td>integer</td>
-        <td>
-          observedGeneration represents the .metadata.generation that the condition was set based upon.
-For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-with respect to the current state of the instance.<br/>
-          <br/>
-            <i>Format</i>: int64<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-
-### PowerMonitorInternal.status.kepler
-<sup><sup>[↩ Parent](#powermonitorinternalstatus)</sup></sup>
-
-
-
-
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>currentNumberScheduled</b></td>
-        <td>integer</td>
-        <td>
-          The number of nodes that are running at least 1 power-monitor-internal pod and are
-supposed to run the power-monitor-internal pod.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>desiredNumberScheduled</b></td>
-        <td>integer</td>
-        <td>
-          The total number of nodes that should be running the power-monitor-internal
-pod (including nodes correctly running the power-monitor-internal pod).<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>numberMisscheduled</b></td>
-        <td>integer</td>
-        <td>
-          The number of nodes that are running the power-monitor-internal pod, but are not supposed
-to run the power-monitor-internal pod.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>numberReady</b></td>
-        <td>integer</td>
-        <td>
-          numberReady is the number of nodes that should be running the power-monitor-internal pod
-and have one or more of the power-monitor-internal pod running with a Ready Condition.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>numberAvailable</b></td>
-        <td>integer</td>
-        <td>
-          The number of nodes that should be running the power-monitor-internal pod and have one or
-more of the power-monitor-internal pod running and available<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>numberUnavailable</b></td>
-        <td>integer</td>
-        <td>
-          The number of nodes that should be running the
-power-monitor-internal pod and have none of the power-monitor-internal pod running and available<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>updatedNumberScheduled</b></td>
-        <td>integer</td>
-        <td>
-          The total number of nodes that are running updated power-monitor-internal pod<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-## PowerMonitor
-<sup><sup>[↩ Parent](#keplersystemsustainablecomputingiov1alpha1 )</sup></sup>
-
-
-
+#### PowerMonitor
 
 
 
 PowerMonitor is the Schema for the PowerMonitor API
 
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-      <td><b>apiVersion</b></td>
-      <td>string</td>
-      <td>kepler.system.sustainable.computing.io/v1alpha1</td>
-      <td>true</td>
-      </tr>
-      <tr>
-      <td><b>kind</b></td>
-      <td>string</td>
-      <td>PowerMonitor</td>
-      <td>true</td>
-      </tr>
-      <tr>
-      <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">metadata</a></b></td>
-      <td>object</td>
-      <td>Refer to the Kubernetes API documentation for the fields of the `metadata` field.</td>
-      <td>true</td>
-      </tr><tr>
-        <td><b><a href="#powermonitorspec">spec</a></b></td>
-        <td>object</td>
-        <td>
-          PowerMonitorSpec defines the desired state of Power Monitor<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b><a href="#powermonitorstatus">status</a></b></td>
-        <td>object</td>
-        <td>
-          PowerMonitorStatus defines the observed state of Power Monitor<br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
 
 
-### PowerMonitor.spec
-<sup><sup>[↩ Parent](#powermonitor)</sup></sup>
+_Appears in:_
+- [PowerMonitorList](#powermonitorlist)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `kepler.system.sustainable.computing.io/v1alpha1` | | |
+| `kind` _string_ | `PowerMonitor` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[PowerMonitorSpec](#powermonitorspec)_ |  |  |  |
+| `status` _[PowerMonitorStatus](#powermonitorstatus)_ |  |  |  |
+
+
+
+
+
+
+#### PowerMonitorInternal
+
+
+
+PowerMonitorInternal is the Schema for the internal kepler 2 API
+
+
+
+_Appears in:_
+- [PowerMonitorInternalList](#powermonitorinternallist)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `kepler.system.sustainable.computing.io/v1alpha1` | | |
+| `kind` _string_ | `PowerMonitorInternal` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[PowerMonitorInternalSpec](#powermonitorinternalspec)_ |  |  |  |
+| `status` _[PowerMonitorInternalStatus](#powermonitorinternalstatus)_ |  |  |  |
+
+
+#### PowerMonitorInternalDashboardSpec
+
+
+
+PowerMonitorInternalDashboardSpec defines settings for the Kepler Grafana dashboard
+
+
+
+_Appears in:_
+- [PowerMonitorInternalOpenShiftSpec](#powermonitorinternalopenshiftspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `enabled` _boolean_ | Enabled controls whether to deploy the Grafana dashboard | false |  |
+
+
+#### PowerMonitorInternalKeplerConfigSpec
+
+
+
+PowerMonitorInternalKeplerConfigSpec defines configuration options for internal Kepler deployment
+
+
+
+_Appears in:_
+- [PowerMonitorInternalKeplerSpec](#powermonitorinternalkeplerspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `logLevel` _string_ | LogLevel sets the logging verbosity (e.g., debug, info, warn, error) | info |  |
+| `additionalConfigMaps` _[ConfigMapRef](#configmapref) array_ | AdditionalConfigMaps is a list of ConfigMap names that will be merged with the default ConfigMap<br />These AdditionalConfigMaps must exist in the same namespace as PowerMonitor components |  |  |
+| `metricLevels` _string array_ | MetricLevels specifies which metrics levels to export<br />Valid values are combinations of: node, process, container, vm, pod | [node pod vm] | items:Enum: [node process container vm pod] <br /> |
+| `staleness` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#duration-v1-meta)_ | Staleness specifies how long to wait before considering calculated power values as stale<br />Must be a positive duration (e.g., "500ms", "5s", "1h"). Negative values are not allowed. | 500ms | Pattern: `^[0-9]+(\.[0-9]+)?(ns\|us\|ms\|s\|m\|h)$` <br />Type: string <br /> |
+| `sampleRate` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#duration-v1-meta)_ | SampleRate specifies the interval for monitoring resources (processes, containers, vms, etc.)<br />Must be a positive duration (e.g., "5s", "1m", "30s"). Negative values are not allowed. | 5s | Pattern: `^[0-9]+(\.[0-9]+)?(ns\|us\|ms\|s\|m\|h)$` <br />Type: string <br /> |
+| `maxTerminated` _integer_ | MaxTerminated controls terminated workload tracking behavior<br />Negative values: track unlimited terminated workloads (no capacity limit)<br />Zero: disable terminated workload tracking completely<br />Positive values: track top N terminated workloads by energy consumption | 0 |  |
+
+
+#### PowerMonitorInternalKeplerDeploymentSpec
+
+
+
+PowerMonitorInternalKeplerDeploymentSpec extends PowerMonitorKeplerDeploymentSpec with internal deployment settings
+
+
+
+_Appears in:_
+- [PowerMonitorInternalKeplerSpec](#powermonitorinternalkeplerspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `nodeSelector` _object (keys:string, values:string)_ | NodeSelector defines which Nodes the Pod is scheduled on | \{ kubernetes.io/os:linux \} |  |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | If specified, define Pod's tolerations | [map[effect: key: operator:Exists value:]] |  |
+| `security` _[PowerMonitorKeplerDeploymentSecuritySpec](#powermonitorkeplerdeploymentsecurityspec)_ | If set, defines the security mode and allowed SANames |  |  |
+| `secrets` _[SecretRef](#secretref) array_ | Secrets to be mounted in the power monitor containers |  |  |
+| `image` _string_ | Image specifies the Kepler container image |  | MinLength: 3 <br /> |
+| `kubeRbacProxyImage` _string_ | KubeRbacProxyImage specifies the kube-rbac-proxy sidecar image |  | MinLength: 3 <br /> |
+| `namespace` _string_ | Namespace specifies the namespace where Kepler will be deployed |  | MinLength: 1 <br /> |
+
+
+#### PowerMonitorInternalKeplerSpec
+
+
+
+PowerMonitorInternalKeplerSpec defines the internal Kepler component specification
+
+
+
+_Appears in:_
+- [PowerMonitorInternalSpec](#powermonitorinternalspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `deployment` _[PowerMonitorInternalKeplerDeploymentSpec](#powermonitorinternalkeplerdeploymentspec)_ | Deployment contains the deployment settings for the internal Kepler DaemonSet |  | Required: \{\} <br /> |
+| `config` _[PowerMonitorInternalKeplerConfigSpec](#powermonitorinternalkeplerconfigspec)_ | Config contains the configuration options for internal Kepler |  |  |
+
+
+#### PowerMonitorInternalKeplerStatus
+
+
+
+PowerMonitorInternalKeplerStatus defines the observed state of the internal Kepler DaemonSet
+
+
+
+_Appears in:_
+- [PowerMonitorInternalStatus](#powermonitorinternalstatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `currentNumberScheduled` _integer_ | CurrentNumberScheduled is the number of nodes that are running at least 1 power-monitor-internal pod and are<br />supposed to run the power-monitor-internal pod. |  |  |
+| `numberMisscheduled` _integer_ | The number of nodes that are running the power-monitor-internal pod, but are not supposed<br />to run the power-monitor-internal pod. |  |  |
+| `desiredNumberScheduled` _integer_ | The total number of nodes that should be running the power-monitor-internal<br />pod (including nodes correctly running the power-monitor-internal pod). |  |  |
+| `numberReady` _integer_ | numberReady is the number of nodes that should be running the power-monitor-internal pod<br />and have one or more of the power-monitor-internal pod running with a Ready Condition. |  |  |
+| `updatedNumberScheduled` _integer_ | The total number of nodes that are running updated power-monitor-internal pod |  |  |
+| `numberAvailable` _integer_ | The number of nodes that should be running the power-monitor-internal pod and have one or<br />more of the power-monitor-internal pod running and available |  |  |
+| `numberUnavailable` _integer_ | The number of nodes that should be running the<br />power-monitor-internal pod and have none of the power-monitor-internal pod running and available |  |  |
+
+
+#### PowerMonitorInternalList
+
+
+
+PowerMonitorInternalList contains a list of PowerMonitorInternal
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `kepler.system.sustainable.computing.io/v1alpha1` | | |
+| `kind` _string_ | `PowerMonitorInternalList` | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#listmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `items` _[PowerMonitorInternal](#powermonitorinternal) array_ |  |  |  |
+
+
+#### PowerMonitorInternalOpenShiftSpec
+
+
+
+PowerMonitorInternalOpenShiftSpec defines OpenShift-specific settings
+
+
+
+_Appears in:_
+- [PowerMonitorInternalSpec](#powermonitorinternalspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `enabled` _boolean_ | Enabled controls whether OpenShift-specific features are enabled | true |  |
+| `dashboard` _[PowerMonitorInternalDashboardSpec](#powermonitorinternaldashboardspec)_ | Dashboard configures the Grafana dashboard deployment |  |  |
+
+
+#### PowerMonitorInternalSpec
+
+
+
+PowerMonitorInternalSpec defines the desired state of PowerMonitorInternal
+
+
+
+_Appears in:_
+- [PowerMonitorInternal](#powermonitorinternal)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `kepler` _[PowerMonitorInternalKeplerSpec](#powermonitorinternalkeplerspec)_ | Kepler contains the Kepler component specification |  | Required: \{\} <br /> |
+| `openshift` _[PowerMonitorInternalOpenShiftSpec](#powermonitorinternalopenshiftspec)_ | OpenShift contains OpenShift-specific settings |  |  |
+
+
+#### PowerMonitorInternalStatus
+
+
+
+PowerMonitorInternalStatus defines the observed state of PowerMonitorInternal
+
+
+
+_Appears in:_
+- [PowerMonitorInternal](#powermonitorinternal)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `kepler` _[PowerMonitorInternalKeplerStatus](#powermonitorinternalkeplerstatus)_ | Kepler contains the status of the internal Kepler DaemonSet |  |  |
+| `conditions` _[Condition](#condition) array_ | conditions represent the latest available observations of power-monitor-internal |  |  |
+
+
+#### PowerMonitorKeplerConfigSpec
+
+
+
+PowerMonitorKeplerConfigSpec defines configuration options for Kepler
+
+
+
+_Appears in:_
+- [PowerMonitorKeplerSpec](#powermonitorkeplerspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `logLevel` _string_ | LogLevel sets the logging verbosity (e.g., debug, info, warn, error) | info |  |
+| `additionalConfigMaps` _[ConfigMapRef](#configmapref) array_ | AdditionalConfigMaps is a list of ConfigMap names that will be merged with the default ConfigMap<br />These AdditionalConfigMaps must exist in the same namespace as PowerMonitor components |  |  |
+| `metricLevels` _string array_ | MetricLevels specifies which metrics levels to export<br />Valid values are combinations of: node, process, container, vm, pod | [node pod vm] | items:Enum: [node process container vm pod] <br /> |
+| `staleness` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#duration-v1-meta)_ | Staleness specifies how long to wait before considering calculated power values as stale<br />Must be a positive duration (e.g., "500ms", "5s", "1h"). Negative values are not allowed. | 500ms | Pattern: `^[0-9]+(\.[0-9]+)?(ns\|us\|ms\|s\|m\|h)$` <br />Type: string <br /> |
+| `sampleRate` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#duration-v1-meta)_ | SampleRate specifies the interval for monitoring resources (processes, containers, vms, etc.)<br />Must be a positive duration (e.g., "5s", "1m", "30s"). Negative values are not allowed. | 5s | Pattern: `^[0-9]+(\.[0-9]+)?(ns\|us\|ms\|s\|m\|h)$` <br />Type: string <br /> |
+| `maxTerminated` _integer_ | MaxTerminated controls terminated workload tracking behavior<br />Negative values: track unlimited terminated workloads (no capacity limit)<br />Zero: disable terminated workload tracking completely<br />Positive values: track top N terminated workloads by energy consumption | 0 |  |
+
+
+#### PowerMonitorKeplerDeploymentSecuritySpec
+
+
+
+PowerMonitorKeplerDeploymentSecuritySpec defines security settings for the Kepler deployment
+
+
+
+_Appears in:_
+- [PowerMonitorInternalKeplerDeploymentSpec](#powermonitorinternalkeplerdeploymentspec)
+- [PowerMonitorKeplerDeploymentSpec](#powermonitorkeplerdeploymentspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `mode` _[SecurityMode](#securitymode)_ | Mode specifies the security mode (none or rbac) |  | Enum: [none rbac] <br /> |
+| `allowedSANames` _string array_ | AllowedSANames lists service account names allowed to access Kepler metrics |  |  |
+
+
+#### PowerMonitorKeplerDeploymentSpec
+
+
+
+PowerMonitorKeplerDeploymentSpec defines deployment settings for the Kepler DaemonSet
+
+
+
+_Appears in:_
+- [PowerMonitorInternalKeplerDeploymentSpec](#powermonitorinternalkeplerdeploymentspec)
+- [PowerMonitorKeplerSpec](#powermonitorkeplerspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `nodeSelector` _object (keys:string, values:string)_ | NodeSelector defines which Nodes the Pod is scheduled on | \{ kubernetes.io/os:linux \} |  |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | If specified, define Pod's tolerations | [map[effect: key: operator:Exists value:]] |  |
+| `security` _[PowerMonitorKeplerDeploymentSecuritySpec](#powermonitorkeplerdeploymentsecurityspec)_ | If set, defines the security mode and allowed SANames |  |  |
+| `secrets` _[SecretRef](#secretref) array_ | Secrets to be mounted in the power monitor containers |  |  |
+
+
+#### PowerMonitorKeplerSpec
+
+
+
+PowerMonitorKeplerSpec defines the Kepler component specification
+
+
+
+_Appears in:_
+- [PowerMonitorSpec](#powermonitorspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `deployment` _[PowerMonitorKeplerDeploymentSpec](#powermonitorkeplerdeploymentspec)_ | Deployment contains the deployment settings for the Kepler DaemonSet |  |  |
+| `config` _[PowerMonitorKeplerConfigSpec](#powermonitorkeplerconfigspec)_ | Config contains the configuration options for Kepler |  |  |
+
+
+#### PowerMonitorKeplerStatus
+
+
+
+PowerMonitorKeplerStatus defines the observed state of the Kepler DaemonSet
+
+
+
+_Appears in:_
+- [PowerMonitorStatus](#powermonitorstatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `currentNumberScheduled` _integer_ | CurrentNumberScheduled is the number of nodes that are running at least 1 power-monitor pod and are<br />supposed to run the power-monitor pod. |  |  |
+| `numberMisscheduled` _integer_ | The number of nodes that are running the power-monitor pod, but are not supposed<br />to run the power-monitor pod. |  |  |
+| `desiredNumberScheduled` _integer_ | The total number of nodes that should be running the power-monitor<br />pod (including nodes correctly running the power-monitor pod). |  |  |
+| `numberReady` _integer_ | numberReady is the number of nodes that should be running the power-monitor pod<br />and have one or more of the power-monitor pod running with a Ready Condition. |  |  |
+| `updatedNumberScheduled` _integer_ | The total number of nodes that are running updated power-monitor pod |  |  |
+| `numberAvailable` _integer_ | The number of nodes that should be running the power-monitor pod and have one or<br />more of the power-monitor pod running and available |  |  |
+| `numberUnavailable` _integer_ | The number of nodes that should be running the<br />power-monitor pod and have none of the power-monitor pod running and available |  |  |
+
+
+#### PowerMonitorList
+
+
+
+PowerMonitorList contains a list of PowerMonitor
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `kepler.system.sustainable.computing.io/v1alpha1` | | |
+| `kind` _string_ | `PowerMonitorList` | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#listmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `items` _[PowerMonitor](#powermonitor) array_ |  |  |  |
+
+
+#### PowerMonitorSpec
 
 
 
 PowerMonitorSpec defines the desired state of Power Monitor
 
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b><a href="#powermonitorspeckepler">kepler</a></b></td>
-        <td>object</td>
-        <td>
-          <br/>
-        </td>
-        <td>true</td>
-      </tr></tbody>
-</table>
 
 
-### PowerMonitor.spec.kepler
-<sup><sup>[↩ Parent](#powermonitorspec)</sup></sup>
+_Appears in:_
+- [PowerMonitor](#powermonitor)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `kepler` _[PowerMonitorKeplerSpec](#powermonitorkeplerspec)_ |  |  |  |
+
+
+#### PowerMonitorStatus
 
 
 
-
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b><a href="#powermonitorspeckeplerconfig">config</a></b></td>
-        <td>object</td>
-        <td>
-          <br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b><a href="#powermonitorspeckeplerdeployment">deployment</a></b></td>
-        <td>object</td>
-        <td>
-          <br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-
-### PowerMonitor.spec.kepler.config
-<sup><sup>[↩ Parent](#powermonitorspeckepler)</sup></sup>
+PowerMonitorStatus defines the observed state of Power Monitor
 
 
 
+_Appears in:_
+- [PowerMonitor](#powermonitor)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `kepler` _[PowerMonitorKeplerStatus](#powermonitorkeplerstatus)_ |  |  |  |
+| `conditions` _[Condition](#condition) array_ | conditions represent the latest available observations of power-monitor |  |  |
 
 
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b><a href="#powermonitorspeckeplerconfigadditionalconfigmapsindex">additionalConfigMaps</a></b></td>
-        <td>[]object</td>
-        <td>
-          AdditionalConfigMaps is a list of ConfigMap names that will be merged with the default ConfigMap
-These AdditionalConfigMaps must exist in the same namespace as PowerMonitor components<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>logLevel</b></td>
-        <td>string</td>
-        <td>
-          <br/>
-          <br/>
-            <i>Default</i>: info<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>maxTerminated</b></td>
-        <td>integer</td>
-        <td>
-          MaxTerminated controls terminated workload tracking behavior
-Negative values: track unlimited terminated workloads (no capacity limit)
-Zero: disable terminated workload tracking completely
-Positive values: track top N terminated workloads by energy consumption<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Default</i>: 0<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>metricLevels</b></td>
-        <td>[]enum</td>
-        <td>
-          MetricLevels specifies which metrics levels to export
-Valid values are combinations of: node, process, container, vm, pod<br/>
-          <br/>
-            <i>Default</i>: [node pod vm]<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>sampleRate</b></td>
-        <td>string</td>
-        <td>
-          SampleRate specifies the interval for monitoring resources (processes, containers, vms, etc.)
-Must be a positive duration (e.g., "5s", "1m", "30s"). Negative values are not allowed.<br/>
-          <br/>
-            <i>Default</i>: 5s<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>staleness</b></td>
-        <td>string</td>
-        <td>
-          Staleness specifies how long to wait before considering calculated power values as stale
-Must be a positive duration (e.g., "500ms", "5s", "1h"). Negative values are not allowed.<br/>
-          <br/>
-            <i>Default</i>: 500ms<br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-
-### PowerMonitor.spec.kepler.config.additionalConfigMaps[index]
-<sup><sup>[↩ Parent](#powermonitorspeckeplerconfig)</sup></sup>
-
-
-
-ConfigMapRef defines a reference to a ConfigMap
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>name</b></td>
-        <td>string</td>
-        <td>
-          Name of the ConfigMap<br/>
-        </td>
-        <td>true</td>
-      </tr></tbody>
-</table>
-
-
-### PowerMonitor.spec.kepler.deployment
-<sup><sup>[↩ Parent](#powermonitorspeckepler)</sup></sup>
-
-
-
-
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>nodeSelector</b></td>
-        <td>map[string]string</td>
-        <td>
-          Defines which Nodes the Pod is scheduled on<br/>
-          <br/>
-            <i>Default</i>: map[kubernetes.io/os:linux]<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b><a href="#powermonitorspeckeplerdeploymentsecretsindex">secrets</a></b></td>
-        <td>[]object</td>
-        <td>
-          Secrets to be mounted in the power monitor containers<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b><a href="#powermonitorspeckeplerdeploymentsecurity">security</a></b></td>
-        <td>object</td>
-        <td>
-          If set, defines the security mode and allowed SANames<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b><a href="#powermonitorspeckeplerdeploymenttolerationsindex">tolerations</a></b></td>
-        <td>[]object</td>
-        <td>
-          If specified, define Pod's tolerations<br/>
-          <br/>
-            <i>Default</i>: [map[effect: key: operator:Exists value:]]<br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-
-### PowerMonitor.spec.kepler.deployment.secrets[index]
-<sup><sup>[↩ Parent](#powermonitorspeckeplerdeployment)</sup></sup>
+#### SecretRef
 
 
 
@@ -1030,334 +503,33 @@ Best practices:
 - Test mount paths in development environments before production deployment
 - Monitor Kepler pod logs for mount-related errors
 
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>mountPath</b></td>
-        <td>string</td>
-        <td>
-          MountPath where the secret should be mounted in the container<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>name</b></td>
-        <td>string</td>
-        <td>
-          Name of the secret in the same namespace as the Kepler deployment<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>readOnly</b></td>
-        <td>boolean</td>
-        <td>
-          ReadOnly specifies whether the secret should be mounted read-only<br/>
-          <br/>
-            <i>Default</i>: true<br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
 
 
-### PowerMonitor.spec.kepler.deployment.security
-<sup><sup>[↩ Parent](#powermonitorspeckeplerdeployment)</sup></sup>
+_Appears in:_
+- [PowerMonitorInternalKeplerDeploymentSpec](#powermonitorinternalkeplerdeploymentspec)
+- [PowerMonitorKeplerDeploymentSpec](#powermonitorkeplerdeploymentspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the secret in the same namespace as the Kepler deployment |  | MinLength: 1 <br />Required: \{\} <br /> |
+| `mountPath` _string_ | MountPath where the secret should be mounted in the container |  | MinLength: 1 <br />Required: \{\} <br /> |
+| `readOnly` _boolean_ | ReadOnly specifies whether the secret should be mounted read-only | true |  |
+
+
+#### SecurityMode
+
+_Underlying type:_ _string_
+
+SecurityMode defines the security mode for Kepler metrics access
 
 
 
-If set, defines the security mode and allowed SANames
+_Appears in:_
+- [PowerMonitorKeplerDeploymentSecuritySpec](#powermonitorkeplerdeploymentsecurityspec)
 
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>allowedSANames</b></td>
-        <td>[]string</td>
-        <td>
-          <br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>mode</b></td>
-        <td>enum</td>
-        <td>
-          <br/>
-          <br/>
-            <i>Enum</i>: none, rbac<br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
+| Field | Description |
+| --- | --- |
+| `none` | SecurityModeNone disables RBAC-based access control for Kepler metrics<br /> |
+| `rbac` | SecurityModeRBAC enables RBAC-based access control for Kepler metrics<br /> |
 
 
-### PowerMonitor.spec.kepler.deployment.tolerations[index]
-<sup><sup>[↩ Parent](#powermonitorspeckeplerdeployment)</sup></sup>
-
-
-
-The pod this Toleration is attached to tolerates any taint that matches
-the triple <key,value,effect> using the matching operator <operator>.
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>effect</b></td>
-        <td>string</td>
-        <td>
-          Effect indicates the taint effect to match. Empty means match all taint effects.
-When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>key</b></td>
-        <td>string</td>
-        <td>
-          Key is the taint key that the toleration applies to. Empty means match all taint keys.
-If the key is empty, operator must be Exists; this combination means to match all values and all keys.<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>operator</b></td>
-        <td>string</td>
-        <td>
-          Operator represents a key's relationship to the value.
-Valid operators are Exists and Equal. Defaults to Equal.
-Exists is equivalent to wildcard for value, so that a pod can
-tolerate all taints of a particular category.<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>tolerationSeconds</b></td>
-        <td>integer</td>
-        <td>
-          TolerationSeconds represents the period of time the toleration (which must be
-of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-it is not set, which means tolerate the taint forever (do not evict). Zero and
-negative values will be treated as 0 (evict immediately) by the system.<br/>
-          <br/>
-            <i>Format</i>: int64<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>value</b></td>
-        <td>string</td>
-        <td>
-          Value is the taint value the toleration matches to.
-If the operator is Exists, the value should be empty, otherwise just a regular string.<br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-
-### PowerMonitor.status
-<sup><sup>[↩ Parent](#powermonitor)</sup></sup>
-
-
-
-PowerMonitorStatus defines the observed state of Power Monitor
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b><a href="#powermonitorstatusconditionsindex">conditions</a></b></td>
-        <td>[]object</td>
-        <td>
-          conditions represent the latest available observations of power-monitor<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b><a href="#powermonitorstatuskepler">kepler</a></b></td>
-        <td>object</td>
-        <td>
-          <br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-
-### PowerMonitor.status.conditions[index]
-<sup><sup>[↩ Parent](#powermonitorstatus)</sup></sup>
-
-
-
-
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>lastTransitionTime</b></td>
-        <td>string</td>
-        <td>
-          lastTransitionTime is the last time the condition transitioned from one status to another.
-This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.<br/>
-          <br/>
-            <i>Format</i>: date-time<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>message</b></td>
-        <td>string</td>
-        <td>
-          message is a human readable message indicating details about the transition.
-This may be an empty string.<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>reason</b></td>
-        <td>string</td>
-        <td>
-          reason contains a programmatic identifier indicating the reason for the condition's last transition.<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>status</b></td>
-        <td>string</td>
-        <td>
-          status of the condition, one of True, False, Unknown.<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>type</b></td>
-        <td>string</td>
-        <td>
-          Type of Kepler Condition - Reconciled, Available ...<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>observedGeneration</b></td>
-        <td>integer</td>
-        <td>
-          observedGeneration represents the .metadata.generation that the condition was set based upon.
-For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-with respect to the current state of the instance.<br/>
-          <br/>
-            <i>Format</i>: int64<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-
-### PowerMonitor.status.kepler
-<sup><sup>[↩ Parent](#powermonitorstatus)</sup></sup>
-
-
-
-
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>currentNumberScheduled</b></td>
-        <td>integer</td>
-        <td>
-          The number of nodes that are running at least 1 power-monitor pod and are
-supposed to run the power-monitor pod.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>desiredNumberScheduled</b></td>
-        <td>integer</td>
-        <td>
-          The total number of nodes that should be running the power-monitor
-pod (including nodes correctly running the power-monitor pod).<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>numberMisscheduled</b></td>
-        <td>integer</td>
-        <td>
-          The number of nodes that are running the power-monitor pod, but are not supposed
-to run the power-monitor pod.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>numberReady</b></td>
-        <td>integer</td>
-        <td>
-          numberReady is the number of nodes that should be running the power-monitor pod
-and have one or more of the power-monitor pod running with a Ready Condition.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>numberAvailable</b></td>
-        <td>integer</td>
-        <td>
-          The number of nodes that should be running the power-monitor pod and have one or
-more of the power-monitor pod running and available<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>numberUnavailable</b></td>
-        <td>integer</td>
-        <td>
-          The number of nodes that should be running the
-power-monitor pod and have none of the power-monitor pod running and available<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>updatedNumberScheduled</b></td>
-        <td>integer</td>
-        <td>
-          The total number of nodes that are running updated power-monitor pod<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>

--- a/hack/crd-ref-docs-config.yaml
+++ b/hack/crd-ref-docs-config.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 The Kepler Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Configuration for crd-ref-docs
+# For more informtaion see: https://github.com/elastic/crd-ref-docs
+processor:
+  ignoreTypes:
+    - "SecurityConfig$"  # Webhook-internal type, not part of CRD spec
+  ignoreFields:
+    - "TypeMeta$"        # Avoid duplicate kind/apiVersion rows
+render:
+  kubernetesVersion: "1.32"

--- a/hack/tools.sh
+++ b/hack/tools.sh
@@ -15,7 +15,7 @@ declare -r KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-v5.8.0}
 declare -r CONTROLLER_TOOLS_VERSION=${CONTROLLER_TOOLS_VERSION:-v0.19.0}
 declare -r OPERATOR_SDK_VERSION=${OPERATOR_SDK_VERSION:-v1.41.1}
 declare -r YQ_VERSION=${YQ_VERSION:-v4.34.2}
-declare -r CRDOC_VERSION=${CRDOC_VERSION:-v0.6.2}
+declare -r CRD_REF_DOCS_VERSION=${CRD_REF_DOCS_VERSION:-v0.2.0}
 declare -r OC_VERSION=${OC_VERSION:-4.18.1}
 declare -r KUBECTL_VERSION=${KUBECTL_VERSION:-v1.28.4}
 declare -r SHFMT_VERSION=${SHFMT_VERSION:-v3.7.0}
@@ -171,15 +171,14 @@ install_shfmt() {
 	go_install mvdan.cc/sh/v3/cmd/shfmt "$SHFMT_VERSION"
 }
 
-version_crdoc() {
-	crdoc --version
+version_crd-ref-docs() {
+	crd-ref-docs --version
 }
 
-install_crdoc() {
-	local version_regex="version $CRDOC_VERSION"
-
-	validate_version crdoc --version "$version_regex" && return 0
-	go_install fybrik.io/crdoc "$CRDOC_VERSION"
+install_crd-ref-docs() {
+	local version_regex="Version: $CRD_REF_DOCS_VERSION"
+	validate_version crd-ref-docs --version "$version_regex" && return 0
+	go_install github.com/elastic/crd-ref-docs "$CRD_REF_DOCS_VERSION"
 }
 
 version_oc() {

--- a/manifests/helm/kepler-operator/crds/kepler.system.sustainable.computing.io_powermonitorinternals.yaml
+++ b/manifests/helm/kepler-operator/crds/kepler.system.sustainable.computing.io_powermonitorinternals.yaml
@@ -68,11 +68,14 @@ spec:
           metadata:
             type: object
           spec:
-            description: PowerMonitorInternalSpec defines the desired state of PowerMonitorInternalSpec
+            description: PowerMonitorInternalSpec defines the desired state of PowerMonitorInternal
             properties:
               kepler:
+                description: Kepler contains the Kepler component specification
                 properties:
                   config:
+                    description: Config contains the configuration options for internal
+                      Kepler
                     properties:
                       additionalConfigMaps:
                         description: |-
@@ -92,6 +95,8 @@ spec:
                         x-kubernetes-list-type: atomic
                       logLevel:
                         default: info
+                        description: LogLevel sets the logging verbosity (e.g., debug,
+                          info, warn, error)
                         type: string
                       maxTerminated:
                         default: 0
@@ -136,14 +141,21 @@ spec:
                         type: string
                     type: object
                   deployment:
+                    description: Deployment contains the deployment settings for the
+                      internal Kepler DaemonSet
                     properties:
                       image:
+                        description: Image specifies the Kepler container image
                         minLength: 3
                         type: string
                       kubeRbacProxyImage:
+                        description: KubeRbacProxyImage specifies the kube-rbac-proxy
+                          sidecar image
                         minLength: 3
                         type: string
                       namespace:
+                        description: Namespace specifies the namespace where Kepler
+                          will be deployed
                         minLength: 1
                         type: string
                       nodeSelector:
@@ -151,7 +163,8 @@ spec:
                           type: string
                         default:
                           kubernetes.io/os: linux
-                        description: Defines which Nodes the Pod is scheduled on
+                        description: NodeSelector defines which Nodes the Pod is scheduled
+                          on
                         type: object
                       secrets:
                         description: Secrets to be mounted in the power monitor containers
@@ -199,11 +212,15 @@ spec:
                           SANames
                         properties:
                           allowedSANames:
+                            description: AllowedSANames lists service account names
+                              allowed to access Kepler metrics
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           mode:
+                            description: Mode specifies the security mode (none or
+                              rbac)
                             enum:
                             - none
                             - rbac
@@ -261,15 +278,21 @@ spec:
                 - deployment
                 type: object
               openshift:
+                description: OpenShift contains OpenShift-specific settings
                 properties:
                   dashboard:
+                    description: Dashboard configures the Grafana dashboard deployment
                     properties:
                       enabled:
                         default: false
+                        description: Enabled controls whether to deploy the Grafana
+                          dashboard
                         type: boolean
                     type: object
                   enabled:
                     default: true
+                    description: Enabled controls whether OpenShift-specific features
+                      are enabled
                     type: boolean
                 required:
                 - enabled
@@ -278,6 +301,8 @@ spec:
             - kepler
             type: object
           status:
+            description: PowerMonitorInternalStatus defines the observed state of
+              PowerMonitorInternal
             properties:
               conditions:
                 description: conditions represent the latest available observations
@@ -325,10 +350,11 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               kepler:
+                description: Kepler contains the status of the internal Kepler DaemonSet
                 properties:
                   currentNumberScheduled:
                     description: |-
-                      The number of nodes that are running at least 1 power-monitor-internal pod and are
+                      CurrentNumberScheduled is the number of nodes that are running at least 1 power-monitor-internal pod and are
                       supposed to run the power-monitor-internal pod.
                     format: int32
                     type: integer

--- a/manifests/helm/kepler-operator/crds/kepler.system.sustainable.computing.io_powermonitors.yaml
+++ b/manifests/helm/kepler-operator/crds/kepler.system.sustainable.computing.io_powermonitors.yaml
@@ -67,8 +67,10 @@ spec:
             description: PowerMonitorSpec defines the desired state of Power Monitor
             properties:
               kepler:
+                description: PowerMonitorKeplerSpec defines the Kepler component specification
                 properties:
                   config:
+                    description: Config contains the configuration options for Kepler
                     properties:
                       additionalConfigMaps:
                         description: |-
@@ -88,6 +90,8 @@ spec:
                         x-kubernetes-list-type: atomic
                       logLevel:
                         default: info
+                        description: LogLevel sets the logging verbosity (e.g., debug,
+                          info, warn, error)
                         type: string
                       maxTerminated:
                         default: 0
@@ -132,13 +136,16 @@ spec:
                         type: string
                     type: object
                   deployment:
+                    description: Deployment contains the deployment settings for the
+                      Kepler DaemonSet
                     properties:
                       nodeSelector:
                         additionalProperties:
                           type: string
                         default:
                           kubernetes.io/os: linux
-                        description: Defines which Nodes the Pod is scheduled on
+                        description: NodeSelector defines which Nodes the Pod is scheduled
+                          on
                         type: object
                       secrets:
                         description: Secrets to be mounted in the power monitor containers
@@ -186,11 +193,15 @@ spec:
                           SANames
                         properties:
                           allowedSANames:
+                            description: AllowedSANames lists service account names
+                              allowed to access Kepler metrics
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           mode:
+                            description: Mode specifies the security mode (none or
+                              rbac)
                             enum:
                             - none
                             - rbac
@@ -294,10 +305,12 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               kepler:
+                description: PowerMonitorKeplerStatus defines the observed state of
+                  the Kepler DaemonSet
                 properties:
                   currentNumberScheduled:
                     description: |-
-                      The number of nodes that are running at least 1 power-monitor pod and are
+                      CurrentNumberScheduled is the number of nodes that are running at least 1 power-monitor pod and are
                       supposed to run the power-monitor pod.
                     format: int32
                     type: integer


### PR DESCRIPTION
This commit switches from using crdoc to crd-ref-docs for generating
API documentation as crdoc is not in active development.

Changes:
- Add type descriptions for SecurityMode, ConditionType, ConditionReason,
  and all Spec/Status types in power_monitor_types.go
- Add type descriptions for all internal types in power_monitor_internal_types.go
- Add comments for enum constants (SecurityMode, ConditionType,
  ConditionReason, ConditionStatus values)
- Add field descriptions for Mode, AllowedSANames, LogLevel, etc.
- Fix incorrect description for PowerMonitorInternalSpec
- Update AGENTS.md with guidance on CRD type documentation