### PR TITLE
chore(rbac): grant nodes read access for kubelet pod informer

### DIFF
--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.23.0
-    createdAt: "2025-11-27T12:36:15Z"
+    createdAt: "2026-02-10T07:27:43Z"
     description: Deploys and Manages Kepler on Kubernetes
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/internal-objects: |-
@@ -111,6 +111,7 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - nodes
           - nodes/metrics
           - nodes/proxy
           - nodes/stats

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -22,6 +22,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
   - nodes/metrics
   - nodes/proxy
   - nodes/stats

--- a/internal/controller/power_monitor_internal.go
+++ b/internal/controller/power_monitor_internal.go
@@ -64,7 +64,7 @@ const (
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=list;watch;create;update;patch;delete
 
 // RBAC required by Kepler exporter
-//+kubebuilder:rbac:groups=core,resources=nodes/metrics;nodes/proxy;nodes/stats,verbs=get;list;watch
+//+kubebuilder:rbac:groups=core,resources=nodes;nodes/metrics;nodes/proxy;nodes/stats,verbs=get;list;watch
 
 // indexAdditonalConfigmaps sets up indexer for PowerMonitorInternal based on referenced ConfigMaps
 func indexAdditonalConfigmaps(mgr ctrl.Manager, logger logr.Logger) error {

--- a/manifests/helm/kepler-operator/templates/rbac.yaml
+++ b/manifests/helm/kepler-operator/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - nodes
       - nodes/metrics
       - nodes/proxy
       - nodes/stats

--- a/pkg/components/power-monitor/deployment.go
+++ b/pkg/components/power-monitor/deployment.go
@@ -259,7 +259,7 @@ func NewPowerMonitorClusterRole(c components.Detail, pmi *v1alpha1.PowerMonitorI
 		},
 		Rules: []rbacv1.PolicyRule{{
 			APIGroups: []string{""},
-			Resources: []string{"nodes/metrics", "nodes/proxy", "nodes/stats", "pods"},
+			Resources: []string{"nodes", "nodes/metrics", "nodes/proxy", "nodes/stats", "pods"},
 			Verbs:     []string{"get", "watch", "list"},
 		}},
 	}

--- a/pkg/components/power-monitor/deployment_test.go
+++ b/pkg/components/power-monitor/deployment_test.go
@@ -265,7 +265,7 @@ func TestPowerMonitorClusterRole(t *testing.T) {
 			spec: v1alpha1.PowerMonitorInternalKeplerSpec{},
 			rules: []rbacv1.PolicyRule{{
 				APIGroups: []string{""},
-				Resources: []string{"nodes/metrics", "nodes/proxy", "nodes/stats", "pods"},
+				Resources: []string{"nodes", "nodes/metrics", "nodes/proxy", "nodes/stats", "pods"},
 				Verbs:     []string{"get", "watch", "list"},
 			}},
 			scenario: "default case",
@@ -283,7 +283,7 @@ func TestPowerMonitorClusterRole(t *testing.T) {
 			rules: []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{""},
-					Resources: []string{"nodes/metrics", "nodes/proxy", "nodes/stats", "pods"},
+					Resources: []string{"nodes", "nodes/metrics", "nodes/proxy", "nodes/stats", "pods"},
 					Verbs:     []string{"get", "watch", "list"},
 				},
 				{


### PR DESCRIPTION
Kepler's kubelet based pod informer needs to read the Node object to auto discover the kubelet endpoint
This commit adds nodes to the clusterrole resources to match Kepler's RBAC requirements