### PR TITLE
chore: add observability category to OLM bundle

### DIFF
--- a/bundle/manifests/kepler-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kepler-operator.clusterserviceversion.yaml
@@ -25,9 +25,9 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    categories: Monitoring
+    categories: Monitoring, Observability
     containerImage: quay.io/sustainable_computing_io/kepler-operator:0.23.0
-    createdAt: "2026-02-10T07:27:43Z"
+    createdAt: "2026-02-11T06:28:32Z"
     description: Deploys and Manages Kepler on Kubernetes
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/internal-objects: |-

--- a/config/manifests/bases/kepler-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kepler-operator.clusterserviceversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     capabilities: Seamless Upgrades
-    categories: Monitoring
+    categories: Monitoring, Observability
     containerImage: <OPERATOR_IMG>
     createdAt: "2023-01-31 16:20:00"
     description: Deploys and Manages Kepler on Kubernetes


### PR DESCRIPTION
This commit adds observability category to OLM bundle ensuring that Operator shows up when selecting
Observability category in OpenShift console.