### PR TITLE
chore(multi-arch-build): modify build process to enable ARM Support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,12 @@ make cluster-up      # Setup local cluster
 make run            # Run operator locally
 git commit -s       # DCO sign-off required
 
+# Cross-compilation (CGO_ENABLED=0, no C cross-compiler needed)
+make build-manager GOARCH=arm64                    # ARM64 binary
+make operator-build GOARCH=arm64                   # ARM64 container image
+make operator-build-multi                          # Multi-arch image build (amd64+arm64), local only
+make operator-push-multi                           # Push multi-arch images and create manifest
+
 # Key Rules
 ✓ SPDX headers in all Go files
 ✓ Use testify for tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # Build the manager binary
-FROM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 
 ARG VERSION
 ARG GIT_COMMIT
 ARG GIT_BRANCH
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -16,25 +17,27 @@ RUN go mod download
 # Copy the go source
 COPY . .
 
-# Build
+# Build - cross-compile natively (CGO_ENABLED=0)
 RUN make build-manager \
+  GOARCH=${TARGETARCH} \
   VERSION=${VERSION} \
   GIT_COMMIT=${GIT_COMMIT} \
   GIT_BRANCH=${GIT_BRANCH}
 
-FROM quay.io/openshift/origin-cli:4.18 AS origincli
-
 FROM registry.access.redhat.com/ubi9-minimal:9.2
+ARG TARGETARCH
 RUN INSTALL_PKGS=" \
   rsync \
   tar \
+  gzip \
   " && \
   microdnf install -y $INSTALL_PKGS && \
   microdnf clean all
+RUN curl -sL "https://mirror.openshift.com/pub/openshift-v4/${TARGETARCH}/clients/ocp/stable/openshift-client-linux.tar.gz" \
+    | tar -xzf - -C /usr/bin oc
 WORKDIR /
 COPY --from=builder /workspace/bin/manager .
 COPY --from=builder /workspace/must-gather/* /usr/bin/
-COPY --from=origincli /usr/bin/oc /usr/bin
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ endif
 ENABLE_WEBHOOKS ?= true # enable webhooks by default
 
 # Setting GOENV
-GOOS := $(shell go env GOOS)
-GOARCH := $(shell go env GOARCH)
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
 
 # VERSION defines the project version for the bundle.
 # Update this value when you upgrade the version of your project.
@@ -57,6 +57,7 @@ KUBE_RBAC_PROXY_IMG_BASE ?= quay.io/brancz/kube-rbac-proxy
 # You can use it as an arg. (E.g make operator-build OPERATOR_IMG=<some-registry>:<version>)
 OPERATOR_IMG ?= $(IMG_BASE)/kepler-operator:$(VERSION)
 ADDITIONAL_TAGS ?=
+IMAGE_ARCHES ?= amd64 arm64
 
 KEPLER_IMG ?= $(KEPLER_IMG_BASE):$(KEPLER_VERSION)
 KUBE_RBAC_PROXY_IMG ?= $(KUBE_RBAC_PROXY_IMG_BASE):$(KUBE_RBAC_PROXY_VERSION)
@@ -189,7 +190,7 @@ build: manifests generate build-manager ## Build manager binary.
 
 .PHONY: build-manager
 build-manager:
-	CGO_ENABLED=$(CGO_ENABLED) go build $(LDFLAGS) -o bin/manager ./cmd/...
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=$(CGO_ENABLED) CC=$(CC) go build $(LDFLAGS) -o bin/manager ./cmd/...
 
 OPENSHIFT ?= true
 RUN_ARGS ?=
@@ -255,9 +256,28 @@ operator-build: manifests generate ## Build docker image with the manager.
 	$(call docker_tag,$(OPERATOR_IMG),$(ADDITIONAL_TAGS))
 
 
+# Build multi-architecture Docker images (local, no push)
+.PHONY: operator-build-multi
+operator-build-multi: manifests generate ## Build multi-arch operator images (local)
+	go mod tidy
+	@for arch in $(IMAGE_ARCHES); do \
+		echo "==> Building operator for linux/$$arch"; \
+		$(MAKE) operator-build GOARCH=$$arch OPERATOR_IMG=$(OPERATOR_IMG)-$$arch; \
+	done
+
 .PHONY: operator-push
 operator-push: ## Push docker image with the manager.
 	$(call docker_push,$(OPERATOR_IMG),$(ADDITIONAL_TAGS))
+
+# Push multi-architecture operator images and create manifest
+.PHONY: operator-push-multi
+operator-push-multi: ## Push multi-arch operator images and create manifest
+	@for arch in $(IMAGE_ARCHES); do \
+		docker push $(OPERATOR_IMG)-$$arch; \
+	done
+	docker manifest create --amend $(OPERATOR_IMG) \
+		$(foreach arch,$(IMAGE_ARCHES),$(OPERATOR_IMG)-$(arch))
+	docker manifest push $(OPERATOR_IMG)
 
 ##@ Deployment
 
@@ -435,6 +455,26 @@ bundle-build: ## Build the bundle image.
 		-t $(BUNDLE_IMG) \
 		--platform=linux/$(GOARCH) .
 	$(call docker_tag,$(BUNDLE_IMG),$(ADDITIONAL_TAGS))
+
+# Build multi-architecture bundle images (local, no push)
+.PHONY: bundle-build-multi
+bundle-build-multi: ## Build multi-arch bundle images (local)
+	@for arch in $(IMAGE_ARCHES); do \
+		echo "==> Building bundle for linux/$$arch"; \
+		docker build -f bundle.Dockerfile \
+			-t $(BUNDLE_IMG)-$$arch \
+			--platform=linux/$$arch .; \
+	done
+
+# Push multi-architecture bundle images and create manifest
+.PHONY: bundle-push-multi
+bundle-push-multi: ## Push multi-arch bundle images and create manifest
+	@for arch in $(IMAGE_ARCHES); do \
+		docker push $(BUNDLE_IMG)-$$arch; \
+	done
+	docker manifest create --amend $(BUNDLE_IMG) \
+		$(foreach arch,$(IMAGE_ARCHES),$(BUNDLE_IMG)-$(arch))
+	docker manifest push $(BUNDLE_IMG)
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -92,5 +92,6 @@ This documentation is for:
 ## Developer Guides
 
 - [E2E Tests](e2e-tests.md) - Test architecture, writing new tests, and CI integration
+- [Multi Architecture Guide](multi-arch-builds.md) - Building for ARM64 and multi-arch container images
 - [Helm Chart Maintenance](helm-chart-maintenance.md) - How to update and maintain the Helm chart
 - [Pre-commit Hooks](pre-commit-hooks.md) - Setting up and using pre-commit hooks

--- a/docs/developer/multi-arch-builds.md
+++ b/docs/developer/multi-arch-builds.md
@@ -1,0 +1,86 @@
+<!-- SPDX-FileCopyrightText: 2025 The Kepler Authors -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Cross-Compilation Guide
+
+Kepler Operator supports building for multiple architectures (amd64, arm64).
+Since the operator uses `CGO_ENABLED=0`, Go handles cross-compilation natively
+— no C cross-compiler or sysroot is needed.
+
+## Building ARM64 Binaries
+
+```bash
+# Cross-compile binary for ARM64
+make build-manager GOARCH=arm64
+```
+
+## Building Container Images
+
+### Single-arch
+
+```bash
+# Build an ARM64 container image (loads into local Docker)
+make operator-build GOARCH=arm64
+
+# Build an amd64 container image (default)
+make operator-build
+```
+
+### Multi-arch
+
+Multi-arch builds use per-arch `docker build` followed by `docker manifest` to
+create a manifest list. Images are built locally, then pushed and assembled
+into a manifest in a separate step.
+
+```bash
+# Build multi-arch operator images locally (amd64 + arm64)
+make operator-build-multi
+
+# Push images and create multi-arch manifest
+make operator-push-multi
+
+# Same for bundle images
+make bundle-build-multi
+make bundle-push-multi
+
+# Customize architectures
+make operator-build-multi IMAGE_ARCHES="amd64 arm64 ppc64le"
+```
+
+### Full multi-arch build and deploy workflow
+
+```bash
+# Build multi-arch operator + generate bundle + build multi-arch bundle
+make operator-build-multi bundle bundle-build-multi \
+  IMG_BASE=quay.io/your-registry \
+  VERSION=0.0.0-dev \
+  KEPLER_IMG=quay.io/your-registry/kepler:latest
+
+# Push all images and create manifests
+make operator-push-multi bundle-push-multi \
+  IMG_BASE=quay.io/your-registry \
+  VERSION=0.0.0-dev
+
+# Deploy via OLM
+operator-sdk run bundle quay.io/your-registry/kepler-operator-bundle:0.0.0-dev \
+  --install-mode AllNamespaces \
+  --namespace operators
+```
+
+## How it works
+
+The Dockerfile uses `FROM --platform=$BUILDPLATFORM` on the builder stage so the
+Go compiler always runs natively on the host architecture. Cross-compilation is
+achieved by passing `GOARCH=$TARGETARCH` to `go build`. This avoids QEMU
+emulation entirely, making builds fast and reliable.
+
+The `oc` CLI (needed for must-gather) is downloaded from the official OpenShift
+mirror for the target architecture rather than pulled from a container image,
+ensuring ARM64 support.
+
+## Makefile Variables
+
+| Variable       | Default        | Description                                   |
+|----------------|----------------|-----------------------------------------------|
+| `GOARCH`       | host arch      | Target architecture for single-arch builds    |
+| `IMAGE_ARCHES` | `amd64 arm64`  | Architectures built by `*-multi` targets      |

--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -167,7 +167,11 @@ To test must-gather changes locally:
 1. Build the operator image with your changes:
 
    ```sh
+   # Single-arch (default: amd64)
    make operator-build operator-push IMG_BASE=<your-registry>
+
+   # Multi-arch (amd64 + arm64)
+   make operator-build-multi operator-push-multi IMG_BASE=<your-registry>
    ```
 
 2. Run must-gather with your custom image:


### PR DESCRIPTION
- Cross-compile via BUILDPLATFORM/TARGETARCH with auto cross-compiler install (amd64<->arm64) in Dockerfile
- Created relevant targets to build and push operator and bundle with docker buildx
- Added cross compilation developer documentation guides